### PR TITLE
fix: converged cycle dependent recomputation

### DIFF
--- a/src/Evaluator.ts
+++ b/src/Evaluator.ts
@@ -245,29 +245,45 @@ export class Evaluator {
     const changes = ContentChanges.empty()
     const cyclicSet = new Set(cycled)
 
-    const dependents = new Set<FormulaVertex>()
+    const dependents: Vertex[] = []
     for (const vertex of cycled) {
       for (const dependent of this.dependencyGraph.graph.adjacentNodes(vertex)) {
-        if (!cyclicSet.has(dependent) && dependent instanceof FormulaVertex) {
-          dependents.add(dependent)
+        if (!cyclicSet.has(dependent)) {
+          dependents.push(dependent)
         }
       }
     }
 
-    if (dependents.size === 0) {
+    if (dependents.length === 0) {
       return changes
     }
 
-    const {sorted} = this.dependencyGraph.topSortWithScc()
-    for (const vertex of sorted) {
-      if (dependents.has(vertex as FormulaVertex)) {
-        const formulaVertex = vertex as FormulaVertex
-        const newCellValue = this.recomputeFormulaVertexValue(formulaVertex)
-        const address = formulaVertex.getAddress(this.lazilyTransformingAstService)
-        this.columnSearch.add(getRawValue(newCellValue), address)
-        changes.addChange(newCellValue, address)
+    this.dependencyGraph.graph.getTopSortedWithSccSubgraphFrom(
+      dependents,
+      (vertex: Vertex) => {
+        if (vertex instanceof FormulaVertex) {
+          const currentValue = vertex.isComputed() ? vertex.getCellValue() : undefined
+          const newCellValue = this.recomputeFormulaVertexValue(vertex)
+          if (newCellValue !== currentValue) {
+            const address = vertex.getAddress(this.lazilyTransformingAstService)
+            changes.addChange(newCellValue, address)
+            this.columnSearch.change(getRawValue(currentValue), getRawValue(newCellValue), address)
+            return true
+          }
+          return false
+        } else if (vertex instanceof RangeVertex) {
+          vertex.clearCache()
+          return true
+        } else {
+          return true
+        }
+      },
+      (vertex: Vertex) => {
+        if (vertex instanceof RangeVertex) {
+          vertex.clearCache()
+        }
       }
-    }
+    )
 
     return changes
   }

--- a/test/circular-dependencies.spec.ts
+++ b/test/circular-dependencies.spec.ts
@@ -446,6 +446,49 @@ describe('Circular Dependencies', () => {
       expect(valueB).toBeCloseTo(2, 8)
     })
 
+    it('updates non-cyclic dependents after cycle convergence', () => {
+      const engine = HyperFormula.buildFromArray([['=0.5*B1+1', '1', '=A1+B1', '=C1*2']], {
+        allowCircularReferences: true,
+        maxIterations: 1000,
+      })
+
+      engine.setCellContents(adr('B1'), [['=0.5*A1+1']])
+
+      expect(engine.getCellValue(adr('A1'))).toBeCloseTo(2, 8)
+      expect(engine.getCellValue(adr('B1'))).toBeCloseTo(2, 8)
+      expect(engine.getCellValue(adr('C1'))).toBeCloseTo(4, 8)
+      expect(engine.getCellValue(adr('D1'))).toBeCloseTo(8, 8)
+    })
+
+    it('updates cascading non-cyclic dependents after cycle convergence', () => {
+      const engine = HyperFormula.buildFromArray([['=0.5*B1+1', '1', '=A1+B1', '=C1*2', '=D1+3']], {
+        allowCircularReferences: true,
+        maxIterations: 1000,
+      })
+
+      engine.setCellContents(adr('B1'), [['=0.5*A1+1']])
+
+      expect(engine.getCellValue(adr('A1'))).toBeCloseTo(2, 8)
+      expect(engine.getCellValue(adr('B1'))).toBeCloseTo(2, 8)
+      expect(engine.getCellValue(adr('C1'))).toBeCloseTo(4, 8)
+      expect(engine.getCellValue(adr('D1'))).toBeCloseTo(8, 8)
+      expect(engine.getCellValue(adr('E1'))).toBeCloseTo(11, 8)
+    })
+
+    it('updates range dependents after cycle convergence', () => {
+      const engine = HyperFormula.buildFromArray([['=0.5*B1+1', '1', '=SUM(A1:B1)', '=C1*2']], {
+        allowCircularReferences: true,
+        maxIterations: 1000,
+      })
+
+      engine.setCellContents(adr('B1'), [['=0.5*A1+1']])
+
+      expect(engine.getCellValue(adr('A1'))).toBeCloseTo(2, 8)
+      expect(engine.getCellValue(adr('B1'))).toBeCloseTo(2, 8)
+      expect(engine.getCellValue(adr('C1'))).toBeCloseTo(4, 8)
+      expect(engine.getCellValue(adr('D1'))).toBeCloseTo(8, 8)
+    })
+
     it('converging model with low maxIterations produces same result as higher count', () => {
       // A=0.5*B+1, B=0.5*A+1 → converges to 2
       // With contraction factor 0.5, 20 iterations is more than enough


### PR DESCRIPTION
## What changed
Replaced the full-graph sort in `Evaluator.updateNonCyclicDependents` with an incremental subgraph traversal seeded from the affected non-cyclic dependents.

Also added regression coverage for:
- direct downstream formulas after cycle convergence
- deeper cascading dependents
- range-based dependents that require cache invalidation

## Why
Circular iteration convergence was already improved, but downstream non-cyclic dependents were still forcing a full topological sort of the entire dependency graph after edits. On large models that kept recalculation slow.

## Impact
Downstream recomputation after converged cycles now stays scoped to the reachable subgraph instead of the whole dependency graph, while preserving correct `RangeVertex` cache invalidation.

## Validation
- `npx jest test/circular-dependencies.spec.ts`
- `npx tsc --noEmit`
