### PR TITLE
chore: bump hyperformula to 0.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.7",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar-fusion/hyperformula",
-      "version": "0.0.7",
+      "version": "0.0.10",
       "dependencies": {
         "chevrotain": "^6.5.0",
         "tiny-emitter": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"


### PR DESCRIPTION
## What changed
Bumps `@stellar-fusion/hyperformula` from `0.0.9` to `0.0.10`.

Updated:
- `package.json`
- `package-lock.json`

## Why
The converged-cycle dependent recomputation fix has already merged, but it cannot be consumed by downstream packages while the published package version is still `0.0.9`.

`common` CI is still resolving the previously published `0.0.9` artifact, which does not contain the merged fix.

## Impact
Publishing `0.0.10` gives downstream packages a new release artifact that includes the merged engine fix.

## Notes
This is the release follow-up for the merged engine fix so `common` can move from `0.0.9` to `0.0.10`.
