### PR TITLE
fix: support multiple consecutive % signs in formulas (Excel-compatible)

### DIFF
--- a/src/parser/FormulaParser.ts
+++ b/src/parser/FormulaParser.ts
@@ -560,17 +560,14 @@ export class FormulaParser extends EmbeddedActionsParser {
   })
 
   private rightUnaryOpAtomicExpression: AstRule = this.RULE('rightUnaryOpAtomicExpression', () => {
-    const positiveAtomicExpression = this.SUBRULE(this.positiveAtomicExpression)
+    let expression: Ast = this.SUBRULE(this.positiveAtomicExpression)
 
-    const percentage = this.OPTION(() => {
-      return this.CONSUME(PercentOp)
-    }) as Maybe<ExtendedToken>
+    this.MANY(() => {
+      const percentage = this.CONSUME(PercentOp) as ExtendedToken
+      expression = buildPercentOpAst(expression, percentage.leadingWhitespace)
+    })
 
-    if (percentage) {
-      return buildPercentOpAst(positiveAtomicExpression, percentage.leadingWhitespace)
-    }
-
-    return positiveAtomicExpression
+    return expression
   })
 
   /**

--- a/test/interpreter/operator-percent.spec.ts
+++ b/test/interpreter/operator-percent.spec.ts
@@ -48,6 +48,28 @@ describe('Percent operator', () => {
     expect(engine.getCellValue(adr('A1'))).toEqual(0.01)
   })
 
+  it('supports multiple % signs (Excel-compatible)', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['=4%%'],
+      ['=100%%%'],
+      ['=4%%+1'],
+      ['=2*4%%'],
+    ])
+
+    expect(engine.getCellValue(adr('A1'))).toBeCloseTo(0.0004, 10)
+    expect(engine.getCellValue(adr('A2'))).toBeCloseTo(0.0001, 10)
+    expect(engine.getCellValue(adr('A3'))).toBeCloseTo(1.0004, 10)
+    expect(engine.getCellValue(adr('A4'))).toBeCloseTo(0.0008, 10)
+  })
+
+  it('multi-% formula referencing an undefined name returns #NAME? (matches Excel)', () => {
+    const engine = HyperFormula.buildFromArray([['=100%%*foo']])
+
+    expect(engine.getCellValue(adr('A1'))).toEqualError(
+      detailedError(ErrorType.NAME, ErrorMessage.NamedExpressionName('foo')),
+    )
+  })
+
   it('range value results in VALUE error', () => {
     const engine = HyperFormula.buildFromArray([
       ['1'],

--- a/test/named-expressions.spec.ts
+++ b/test/named-expressions.spec.ts
@@ -2034,6 +2034,7 @@ describe('getNamedExpressionsFromFormula method', () => {
       expect(() => engine.getNamedExpressionsFromFormula('=@foo')).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula("=foo'bar")).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula('=\u00A0foo')).toThrow(new NotAFormulaError())
+      expectArrayWithSameContent(engine.getNamedExpressionsFromFormula('=100%%*foo'), ['foo'])
     })
   })
 
@@ -2112,6 +2113,7 @@ describe('getNamedExpressionsFromFormula method', () => {
       expect(() => engine.getNamedExpressionsFromFormula('=@foo')).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula("=foo'bar")).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula('=\u00A0foo')).toThrow(new NotAFormulaError())
+      expectArrayWithSameContent(engine.getNamedExpressionsFromFormula('=100%%*foo'), ['foo'])
     })
   })
 })

--- a/test/named-expressions.spec.ts
+++ b/test/named-expressions.spec.ts
@@ -2031,7 +2031,6 @@ describe('getNamedExpressionsFromFormula method', () => {
       engine.addNamedExpression('foo', '=42')
 
       expect(() => engine.getNamedExpressionsFromFormula('=#FOO!')).toThrow(new NotAFormulaError())
-      expect(() => engine.getNamedExpressionsFromFormula('=100%%*foo')).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula('=@foo')).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula("=foo'bar")).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula('=\u00A0foo')).toThrow(new NotAFormulaError())
@@ -2110,7 +2109,6 @@ describe('getNamedExpressionsFromFormula method', () => {
       ])
 
       expect(() => engine.getNamedExpressionsFromFormula('=#FOO!')).toThrow(new NotAFormulaError())
-      expect(() => engine.getNamedExpressionsFromFormula('=100%%*foo')).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula('=@foo')).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula("=foo'bar")).toThrow(new NotAFormulaError())
       expect(() => engine.getNamedExpressionsFromFormula('=\u00A0foo')).toThrow(new NotAFormulaError())

--- a/test/parser/percent-operator.spec.ts
+++ b/test/parser/percent-operator.spec.ts
@@ -61,10 +61,25 @@ describe('percent', () => {
     expect(ast.value.type).toBe(AstNodeType.FUNCTION_CALL)
   })
 
-  it('%% should not parse', () => {
+  it('%% parses as nested PERCENT_OP (Excel-compatible)', () => {
     const parser = buildEmptyParserWithCaching(new Config())
 
     const ast = parser.parse('=100%%', adr('A1')).ast as PercentOpAst
-    expect(ast.type).toBe(AstNodeType.ERROR)
+    expect(ast.type).toBe(AstNodeType.PERCENT_OP)
+    const inner = ast.value as PercentOpAst
+    expect(inner.type).toBe(AstNodeType.PERCENT_OP)
+    expect(inner.value.type).toBe(AstNodeType.NUMBER)
+  })
+
+  it('three % signs parse as triple-nested PERCENT_OP', () => {
+    const parser = buildEmptyParserWithCaching(new Config())
+
+    const ast = parser.parse('=100%%%', adr('A1')).ast as PercentOpAst
+    expect(ast.type).toBe(AstNodeType.PERCENT_OP)
+    const inner1 = ast.value as PercentOpAst
+    expect(inner1.type).toBe(AstNodeType.PERCENT_OP)
+    const inner2 = inner1.value as PercentOpAst
+    expect(inner2.type).toBe(AstNodeType.PERCENT_OP)
+    expect(inner2.value.type).toBe(AstNodeType.NUMBER)
   })
 })


### PR DESCRIPTION
Excel allows chaining % signs to compound the divide-by-100 operation (e.g. =4%% evaluates to 0.0004). HyperFormula's grammar rejected the second % as a syntax error. Switched the rightUnaryOpAtomicExpression rule from OPTION to MANY so each % wraps the expression in a nested PercentOpAst. The interpreter and unparser already recurse through PERCENT_OP nodes, so evaluation and round-tripping work without further changes.