### PR TITLE
fix(AVERAGEIF): return 0 instead of #DIV/0! when result is exactly zero

### DIFF
--- a/src/interpreter/plugin/ConditionalAggregationPlugin.ts
+++ b/src/interpreter/plugin/ConditionalAggregationPlugin.ts
@@ -200,7 +200,7 @@ export class ConditionalAggregationPlugin extends FunctionPlugin implements Func
       if (averageResult instanceof CellError) {
         return averageResult
       } else {
-        return averageResult.averageValue() || new CellError(ErrorType.DIV_BY_ZERO)
+        return averageResult.averageValue() ?? new CellError(ErrorType.DIV_BY_ZERO)
       }
     }
 


### PR DESCRIPTION
## Summary

`AverageResult.averageValue()` returns `undefined` for empty match sets and a numeric average otherwise. The previous `||` fallback treated the valid result `0` as falsy and replaced it with `#DIV/0!`. Switching to `??` preserves `0` as a legitimate average while still returning `#DIV/0!` for empty ranges.

## Impact

Any `AVERAGEIF` whose matched values sum to zero — all-zero ranges and offsetting positives/negatives alike — silently produced `#DIV/0!` instead of `0`. In financial models this affects flat-quarter growth rates, hedged FX exposures, and net-zero adjustments.

## Repro

Formula: `=AVERAGEIF(A1:A4, ">=0", B1:B4)` where `B1:B4 = [0, 0, 0, 0]`

- Before: `#DIV/0!`
- After: `0`

## Test plan

- [ ] AVERAGEIF over `[0, 0, 0, 0]` returns `0`
- [ ] AVERAGEIF over `[-5, 5, -3, 3]` returns `0`
- [ ] AVERAGEIF over `[1, 2, 3, 4]` returns `2.5` (unchanged)
- [ ] AVERAGEIF with no matching criteria still returns `#DIV/0!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)