### PR TITLE
chore: bump hyperformula version to 0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"


### PR DESCRIPTION
Bumps the version so the AVERAGEIF fix merged in #25 can be published.