### PR TITLE
fix: scale value by 100 for percent format token in TEXT formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -52,6 +52,20 @@ function countPercentSigns(tokens: FormatToken[]): number {
     .reduce((count, token) => count + countChars(token.value, '%'), 0)
 }
 
+/* Excel rounds halves away from zero (2.5 -> 3, -2.5 -> -3), unlike JS toFixed which rounds
+ * half-to-even on the binary value. Shifting through the decimal string (rather than value * 10**d)
+ * avoids re-introducing floating-point noise. ponytail: values >= 1e15 have no meaningful
+ * fractional digits in a double, so skip the shift (whose `e`-notation string would break) and
+ * return them unchanged. */
+function roundHalfAwayFromZero(value: number, decimals: number): number {
+  if (!isFinite(value) || Math.abs(value) >= 1e15) {
+    return value
+  }
+  const sign = value < 0 ? -1 : 1
+  const shifted = Math.round(Number(`${Math.abs(value)}e${decimals}`))
+  return sign * Number(`${shifted}e${-decimals}`)
+}
+
 function numberFormat(tokens: FormatToken[], value: number): RawScalarValue {
   let result = ''
 
@@ -60,6 +74,14 @@ function numberFormat(tokens: FormatToken[], value: number): RawScalarValue {
    * loop below; here we only scale the numeric value before its digits are formatted. */
   const percentSigns = countPercentSigns(tokens)
   value = value * 100 ** percentSigns
+
+  /* Excel rounds display values to 15 significant digits. Normalising here absorbs binary
+   * floating-point noise (e.g. 0.0295 * 100 === 2.9499999999999997) so the per-token rounding
+   * below matches Excel (2.95 -> "3.0%" rather than "2.9%"). `value` is finite here: the
+   * date/duration branches in `format()` run first, so only real numbers reach `numberFormat`. */
+  if (value !== 0) {
+    value = Number(value.toPrecision(15))
+  }
 
   for (let i = 0; i < tokens.length; ++i) {
     const token = tokens[i]
@@ -74,7 +96,7 @@ function numberFormat(tokens: FormatToken[], value: number): RawScalarValue {
     const separator = tokenParts[1] ? '.' : ''
 
     /* get fixed-point number without trailing zeros */
-    const valueParts = Number(value.toFixed(decimalFormat.length)).toString().split('.')
+    const valueParts = roundHalfAwayFromZero(value, decimalFormat.length).toString().split('.')
     let integerPart = valueParts[0] || ''
     let decimalPart = valueParts[1] || ''
 

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -46,8 +46,20 @@ function countChars(text: string, char: string) {
   return text.split(char).length - 1
 }
 
+function countPercentSigns(tokens: FormatToken[]): number {
+  return tokens
+    .filter((token) => token.type === TokenType.FREE_TEXT)
+    .reduce((count, token) => count + countChars(token.value, '%'), 0)
+}
+
 function numberFormat(tokens: FormatToken[], value: number): RawScalarValue {
   let result = ''
+
+  /* Excel's `%` format token scales the displayed value by 100 for each `%` in the format
+   * (e.g. "0.0%" renders 0.032 as "3.2%"). The `%` literal is emitted as free text by the
+   * loop below; here we only scale the numeric value before its digits are formatted. */
+  const percentSigns = countPercentSigns(tokens)
+  value = value * 100 ** percentSigns
 
   for (let i = 0; i < tokens.length; ++i) {
     const token = tokens[i]

--- a/test/format/format-interpreter.spec.ts
+++ b/test/format/format-interpreter.spec.ts
@@ -47,4 +47,20 @@ describe('FormatInterpreter', () => {
   it('number formatting with additional chars', () => {
     expect(format(1, '$0.00', config, dateHelper)).toEqual('$1.00')
   })
+
+  it('scales by 100 for the percent format token', () => {
+    expect(format(0.032, '0.0%', config, dateHelper)).toEqual('3.2%')
+    expect(format(0.1, '0.0%', config, dateHelper)).toEqual('10.0%')
+    expect(format(0.032, '0.00%', config, dateHelper)).toEqual('3.20%')
+    expect(format(0.5, '0%', config, dateHelper)).toEqual('50%')
+  })
+
+  it('scales by 100 once per percent sign', () => {
+    expect(format(0.5, '0%%', config, dateHelper)).toEqual('5000%%')
+  })
+
+  it('leaves non-percent formats unscaled', () => {
+    expect(format(12.34, '0.00', config, dateHelper)).toEqual('12.34')
+    expect(format(2, 'dd-mm-yyyy', config, dateHelper)).toEqual('01-01-1900')
+  })
 })

--- a/test/format/format-interpreter.spec.ts
+++ b/test/format/format-interpreter.spec.ts
@@ -59,6 +59,20 @@ describe('FormatInterpreter', () => {
     expect(format(0.5, '0%%', config, dateHelper)).toEqual('5000%%')
   })
 
+  it('rounds the percent like Excel despite binary floating-point noise', () => {
+    // 0.0295 * 100 === 2.9499999999999997, which naively rounds down to "2.9%".
+    // Excel normalises to 15 significant digits first, so it shows "3.0%".
+    expect(format(0.0295, '0.0%', config, dateHelper)).toEqual('3.0%')
+  })
+
+  it('rounds halves away from zero like Excel', () => {
+    // 3.15 rounds half-to-even (toFixed) to "3.1"; Excel rounds half away from zero to "3.2".
+    expect(format(0.0315, '0.0%', config, dateHelper)).toEqual('3.2%')
+    expect(format(-0.0315, '0.0%', config, dateHelper)).toEqual('-3.2%')
+    expect(format(2.5, '0', config, dateHelper)).toEqual('3')
+    expect(format(-2.5, '0', config, dateHelper)).toEqual('-3')
+  })
+
   it('leaves non-percent formats unscaled', () => {
     expect(format(12.34, '0.00', config, dateHelper)).toEqual('12.34')
     expect(format(2, 'dd-mm-yyyy', config, dateHelper)).toEqual('01-01-1900')

--- a/test/interpreter/function-text.spec.ts
+++ b/test/interpreter/function-text.spec.ts
@@ -16,6 +16,16 @@ describe('TEXT()', () => {
     expect(engine.getCellValue(adr('B1'))).toEqual('01/01/1900')
   })
 
+  it('formats a fraction as a percentage', () => {
+    const engine = HyperFormula.buildFromArray([
+      [0.032, '=TEXT(A1, "0.0%")'],
+      [0.1, '=TEXT(A2, "0.0%")'],
+    ])
+
+    expect(engine.getCellValue(adr('B1'))).toEqual('3.2%')
+    expect(engine.getCellValue(adr('B2'))).toEqual('10.0%')
+  })
+
   it('wrong number of arguments', () => {
     const engine = HyperFormula.buildFromArray([
       ['=TEXT(42)'],


### PR DESCRIPTION
## Problem

The new whole-model ingestion flow produces ~100 false "source errors" per model that the old Excel add-in flow did not. Investigating model `6a3be138fb7d288e00535cde`, every `Debt Schedule!B*` label (e.g. `SNR Unsec 3-year Fixed 3.2% due 6/21`) recalculated its rate as `0.0%`/`0.1%` instead of the real rate.

Root cause: the number-format engine **emits the `%` literal but never applies Excel's ×100 scaling for it**. `%` falls through `numberFormatRegex` as free text, so:

```
TEXT(0.032, "0.0%")  ->  "0.0%"   (should be "3.2%")
TEXT(0.1,   "0.0%")  ->  "0.1%"   (should be "10.0%")
```

(The `0.0%`/`0.1%` split across saved rates was the tell: low rates rounded to `0.0%`, high rates to `0.1%` — i.e. the raw fraction formatted without the ×100.)

**Why it only surfaced now:** the add-in stored these label cells as static *values* (real Excel had already evaluated `TEXT`), so the engine never formatted a percent. Whole-model ingestion stores the *formulas*, so the engine recomputes every `TEXT(rate,"0.0%")` label and the latent bug fires. The saved Excel data was correct all along — these source errors are false positives.

## Fix

`src/format/format.ts` — scale the value by 100 once per `%` sign before formatting its digits (Excel multiplies by `100^percentSigns`):

```js
const percentSigns = countPercentSigns(tokens)
value = value * 100 ** percentSigns
```

When there are no percent signs, `100 ** 0 === 1`, so dates and plain number formats are untouched. The `%` literal is still emitted by the existing free-text path.

## Two follow-on rounding fixes (same function, found via end-to-end verification)

Running the fix against a real 28MB model showed the ×100 change alone still left ~8 residual 0.1pp mismatches, from two further gaps in `numberFormat`:

1. **Binary FP noise** — `0.0295 * 100 === 2.9499999999999997`, which rounds *down* to `2.9%`. Excel normalises display values to 15 significant digits first, so it shows `3.0%`. Fix: `Number(value.toPrecision(15))` after scaling.
2. **Rounding mode** — JS `toFixed` rounds half-to-even on the binary value (`3.15 -> 3.1`); Excel rounds **half away from zero** (`3.15 -> 3.2`, `-3.15 -> -3.2`). Fix: a `roundHalfAwayFromZero` helper (decimal-string shift to avoid re-introducing FP noise; values ≥ 1e15 are returned unchanged since a double has no fractional digits there).

## Tests

- `format()` unit cases: `0.0%`, `0.00%`, `0%`, multiple `%%`, FP-noise (`0.0295 -> 3.0%`), half-away (`0.0315 -> 3.2%`, negatives, `2.5 -> 3`), and non-percent formats left unscaled.
- `TEXT()` integration: `=TEXT(0.032,"0.0%") -> "3.2%"`, `=TEXT(0.1,"0.0%") -> "10.0%"`.
- **Full suite: 2793 tests / 367 suites pass**; `tsc --noEmit` clean; eslint 0 errors.

## End-to-end verification

Rebuilt this fork, re-bundled into `common` locally, and replayed the source-error lambda path on the affected model: **differenceCount 195 → 0, sourceErrors 98 → 0** (the 1 volatile `TODAY()` cell is handled by the companion source-error-lambda PR #12).

## Notes

- Version bumped `0.0.12 → 0.0.13` for downstream `common` consumption.
- Scope is limited to the percent format token; the `%` *operator* (`=50%`) is unrelated and already handled on master.
- Separate, not in this PR: the source-error comparison has no volatile-function allowlist, so `=TODAY()`/`NOW()` cells (e.g. `Historical Market Data!B1`) will always differ after a later recalc. Tracked for a follow-up in `source-error-lambda`.
