### PR TITLE
fix: TEXT/number formatting — percent scaling, Excel rounding, multi-section formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -113,10 +113,51 @@ function countChars(text: string, char: string) {
   return text.split(char).length - 1
 }
 
+/* Strip Excel format-literal syntax from free text: `\x` escapes (keep x) and `"..."` quote
+ * delimiters, leaving the display text (e.g. `\%` and `"%"` both render as `%`). */
+function renderFormatLiteral(text: string): string {
+  let result = ''
+  for (let i = 0; i < text.length; ++i) {
+    const ch = text[i]
+    if (ch === '\\' && i + 1 < text.length) {
+      result += text[i + 1]
+      ++i
+      continue
+    }
+    if (ch === '"') {
+      continue
+    }
+    result += ch
+  }
+  return result
+}
+
+/* Count only ACTIVE percent signs — Excel format tokens, not display text. An escaped `\%` or a `%`
+ * inside a `"..."` quoted literal is display text and must not scale the value by 100. */
+function countActivePercent(text: string): number {
+  let count = 0
+  let inQuote = false
+  for (let i = 0; i < text.length; ++i) {
+    const ch = text[i]
+    if (ch === '\\' && i + 1 < text.length) {
+      ++i
+      continue
+    }
+    if (ch === '"') {
+      inQuote = !inQuote
+      continue
+    }
+    if (ch === '%' && !inQuote) {
+      ++count
+    }
+  }
+  return count
+}
+
 function countPercentSigns(tokens: FormatToken[]): number {
   return tokens
     .filter((token) => token.type === TokenType.FREE_TEXT)
-    .reduce((count, token) => count + countChars(token.value, '%'), 0)
+    .reduce((count, token) => count + countActivePercent(token.value), 0)
 }
 
 /* Excel rounds halves away from zero (2.5 -> 3, -2.5 -> -3), unlike JS toFixed which rounds
@@ -129,7 +170,15 @@ function roundHalfAwayFromZero(value: number, decimals: number): number {
     return value
   }
   const sign = value < 0 ? -1 : 1
-  const shifted = Math.round(Number(`${Math.abs(value)}e${decimals}`))
+  const abs = Math.abs(value)
+  /* Magnitudes below ~1e-6 stringify in exponent form (e.g. "1e-7"), which would corrupt the
+   * decimal-shift string into "1e-7e2" -> NaN. At that scale a plain numeric shift carries no
+   * half-rounding risk (no representable half lands on a boundary), so use it directly. */
+  if (abs.toString().includes('e')) {
+    const factor = 10 ** decimals
+    return sign * Math.round(abs * factor) / factor
+  }
+  const shifted = Math.round(Number(`${abs}e${decimals}`))
   return sign * Number(`${shifted}e${-decimals}`)
 }
 
@@ -153,7 +202,7 @@ function numberFormat(tokens: FormatToken[], value: number): RawScalarValue {
   for (let i = 0; i < tokens.length; ++i) {
     const token = tokens[i]
     if (token.type === TokenType.FREE_TEXT) {
-      result += token.value
+      result += renderFormatLiteral(token.value)
       continue
     }
 

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -53,7 +53,15 @@ function selectNumberFormatSection(sections: string[], value: number): { section
   return {sectionFormat: sections[0], sectionValue: value}
 }
 
-export function format(value: number, formatArg: string, config: Config, dateHelper: DateTimeHelper): RawScalarValue {
+/* Strip Excel format-literal quoting from a pure-text section: "..." quotes and \ escapes, so an
+ * accounting zero section like "-" renders as - rather than the raw quoted pattern. */
+function stripFormatLiteral(section: string): string {
+  return section.replace(/\\(.)/g, '$1').replace(/"/g, '')
+}
+
+/* Dispatch a single (already section-selected) format through the date, duration, then number
+ * formatters — the original single-format behaviour. */
+function formatSection(value: number, formatArg: string, config: Config, dateHelper: DateTimeHelper): RawScalarValue {
   const tryDateTime = config.stringifyDateTime(dateHelper.numberToSimpleDateTime(value), formatArg) // default points to defaultStringifyDateTime()
   if (tryDateTime !== undefined) {
     return tryDateTime
@@ -64,18 +72,23 @@ export function format(value: number, formatArg: string, config: Config, dateHel
   }
   const expression = parseForNumberFormat(formatArg)
   if (expression !== undefined) {
-    const sections = splitFormatSections(formatArg)
-    if (sections.length <= 1) {
-      return numberFormat(expression.tokens, value)
-    }
-    const {sectionFormat, sectionValue} = selectNumberFormatSection(sections, value)
-    const sectionExpression = parseForNumberFormat(sectionFormat)
-    if (sectionExpression === undefined) {
-      return sectionFormat
-    }
-    return numberFormat(sectionExpression.tokens, sectionValue)
+    return numberFormat(expression.tokens, value)
   }
   return formatArg
+}
+
+export function format(value: number, formatArg: string, config: Config, dateHelper: DateTimeHelper): RawScalarValue {
+  const sections = splitFormatSections(formatArg)
+  if (sections.length <= 1) {
+    return formatSection(value, formatArg, config, dateHelper)
+  }
+  // Select the sign-appropriate section first, then dispatch it through every formatter (date,
+  // duration, number) — not just the number path — so a date/duration first section is honoured.
+  const {sectionFormat, sectionValue} = selectNumberFormatSection(sections, value)
+  const formatted = formatSection(sectionValue, sectionFormat, config, dateHelper)
+  // A pure-text section parses as nothing and round-trips unchanged; strip its quoting so it renders
+  // as display text instead of the raw format pattern.
+  return formatted === sectionFormat ? stripFormatLiteral(sectionFormat) : formatted
 }
 
 export function padLeft(number: number | string, size: number) {

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -42,12 +42,14 @@ function splitFormatSections(formatArg: string): string[] {
 
 /* Pick the section matching the value's sign (Excel rules): positive -> [0]; negative -> [1]
  * formatted with the absolute value (the section supplies its own sign/parens); zero -> [2].
- * Missing negative/zero sections fall back to [0] (where a negative value keeps its `-`). */
+ * An ABSENT (undefined) negative/zero section falls back to [0] (a negative value keeps its `-`);
+ * an EXPLICITLY EMPTY section (e.g. `0;;`) is a valid Excel instruction to display nothing for that
+ * sign, so it is returned as-is and renders as an empty string. */
 function selectNumberFormatSection(sections: string[], value: number): { sectionFormat: string, sectionValue: number } {
-  if (value < 0 && sections[1] !== undefined && sections[1] !== '') {
+  if (value < 0 && sections[1] !== undefined) {
     return {sectionFormat: sections[1], sectionValue: Math.abs(value)}
   }
-  if (value === 0 && sections[2] !== undefined && sections[2] !== '') {
+  if (value === 0 && sections[2] !== undefined) {
     return {sectionFormat: sections[2], sectionValue: value}
   }
   return {sectionFormat: sections[0], sectionValue: value}

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -10,6 +10,49 @@ import {RawScalarValue} from '../interpreter/InterpreterValue'
 import {Maybe} from '../Maybe'
 import {FormatToken, parseForDateTimeFormat, parseForNumberFormat, TokenType} from './parser'
 
+/* Excel number formats may carry up to four `;`-separated sections: positive;negative;zero;text.
+ * Split at the top level only — a `;` inside a quoted literal ("...") or escaped (\;) is literal
+ * text, not a separator. ponytail: the 4th (text) section is irrelevant for numeric values. */
+function splitFormatSections(formatArg: string): string[] {
+  const sections: string[] = []
+  let current = ''
+  let inQuote = false
+  for (let i = 0; i < formatArg.length; ++i) {
+    const char = formatArg[i]
+    if (char === '\\' && i + 1 < formatArg.length) {
+      current += char + formatArg[i + 1]
+      ++i
+      continue
+    }
+    if (char === '"') {
+      inQuote = !inQuote
+      current += char
+      continue
+    }
+    if (char === ';' && !inQuote) {
+      sections.push(current)
+      current = ''
+      continue
+    }
+    current += char
+  }
+  sections.push(current)
+  return sections
+}
+
+/* Pick the section matching the value's sign (Excel rules): positive -> [0]; negative -> [1]
+ * formatted with the absolute value (the section supplies its own sign/parens); zero -> [2].
+ * Missing negative/zero sections fall back to [0] (where a negative value keeps its `-`). */
+function selectNumberFormatSection(sections: string[], value: number): { sectionFormat: string, sectionValue: number } {
+  if (value < 0 && sections[1] !== undefined && sections[1] !== '') {
+    return {sectionFormat: sections[1], sectionValue: Math.abs(value)}
+  }
+  if (value === 0 && sections[2] !== undefined && sections[2] !== '') {
+    return {sectionFormat: sections[2], sectionValue: value}
+  }
+  return {sectionFormat: sections[0], sectionValue: value}
+}
+
 export function format(value: number, formatArg: string, config: Config, dateHelper: DateTimeHelper): RawScalarValue {
   const tryDateTime = config.stringifyDateTime(dateHelper.numberToSimpleDateTime(value), formatArg) // default points to defaultStringifyDateTime()
   if (tryDateTime !== undefined) {
@@ -21,7 +64,16 @@ export function format(value: number, formatArg: string, config: Config, dateHel
   }
   const expression = parseForNumberFormat(formatArg)
   if (expression !== undefined) {
-    return numberFormat(expression.tokens, value)
+    const sections = splitFormatSections(formatArg)
+    if (sections.length <= 1) {
+      return numberFormat(expression.tokens, value)
+    }
+    const {sectionFormat, sectionValue} = selectNumberFormatSection(sections, value)
+    const sectionExpression = parseForNumberFormat(sectionFormat)
+    if (sectionExpression === undefined) {
+      return sectionFormat
+    }
+    return numberFormat(sectionExpression.tokens, sectionValue)
   }
   return formatArg
 }

--- a/test/format/format-interpreter.spec.ts
+++ b/test/format/format-interpreter.spec.ts
@@ -13,6 +13,14 @@ describe('FormatInterpreter', () => {
     expect(format(2, 'dd-mm-yyyy', config, dateHelper)).toEqual('01-01-1900')
   })
 
+  it('selects the date section of a multi-section format and formats it as a date', () => {
+    expect(format(2, 'dd-mm-yyyy;@', config, dateHelper)).toEqual('01-01-1900')
+  })
+
+  it('renders a pure-text section as stripped display text, not the raw quoted pattern', () => {
+    expect(format(0, '#,##0;(#,##0);"-"', config, dateHelper)).toEqual('-')
+  })
+
   it('works with # without decimal separator', () => {
     expect(format(1, '###', config, dateHelper)).toEqual('1')
     expect(format(12, '###', config, dateHelper)).toEqual('12')

--- a/test/format/format-interpreter.spec.ts
+++ b/test/format/format-interpreter.spec.ts
@@ -27,6 +27,17 @@ describe('FormatInterpreter', () => {
     expect(format(0, '0;;', config, dateHelper)).toEqual('')
   })
 
+  it('treats escaped/quoted percent as a display literal (no scaling), but scales a real percent token', () => {
+    expect(format(3, '0\\%', config, dateHelper)).toEqual('3%')
+    expect(format(0.5, '0.0"%"', config, dateHelper)).toEqual('0.5%')
+    expect(format(0.05, '0%', config, dateHelper)).toEqual('5%')
+  })
+
+  it('rounds tiny (exponent-notation) magnitudes without producing NaN', () => {
+    expect(format(0.0000001, '0.00', config, dateHelper)).toEqual('0.00')
+    expect(format(-0.0000001, '0.00', config, dateHelper)).toEqual('0.00')
+  })
+
   it('works with # without decimal separator', () => {
     expect(format(1, '###', config, dateHelper)).toEqual('1')
     expect(format(12, '###', config, dateHelper)).toEqual('12')

--- a/test/format/format-interpreter.spec.ts
+++ b/test/format/format-interpreter.spec.ts
@@ -21,6 +21,12 @@ describe('FormatInterpreter', () => {
     expect(format(0, '#,##0;(#,##0);"-"', config, dateHelper)).toEqual('-')
   })
 
+  it('renders an explicitly empty section as an empty string (Excel display-nothing)', () => {
+    expect(format(5, '0;;', config, dateHelper)).toEqual('5')
+    expect(format(-5, '0;;', config, dateHelper)).toEqual('')
+    expect(format(0, '0;;', config, dateHelper)).toEqual('')
+  })
+
   it('works with # without decimal separator', () => {
     expect(format(1, '###', config, dateHelper)).toEqual('1')
     expect(format(12, '###', config, dateHelper)).toEqual('12')

--- a/test/interpreter/function-text.spec.ts
+++ b/test/interpreter/function-text.spec.ts
@@ -26,6 +26,18 @@ describe('TEXT()', () => {
     expect(engine.getCellValue(adr('B2'))).toEqual('10.0%')
   })
 
+  it('selects the correct section of a multi-section format by sign', () => {
+    const engine = HyperFormula.buildFromArray([
+      [0.0506, '=TEXT(A1, "0%;(0)%")'],
+      [-0.23, '=TEXT(A2, "0%;(0)%")'],
+      [0, '=TEXT(A3, "0%;(0)%")'],
+    ])
+
+    expect(engine.getCellValue(adr('B1'))).toEqual('5%')
+    expect(engine.getCellValue(adr('B2'))).toEqual('(23)%')
+    expect(engine.getCellValue(adr('B3'))).toEqual('0%')
+  })
+
   it('wrong number of arguments', () => {
     const engine = HyperFormula.buildFromArray([
       ['=TEXT(42)'],


### PR DESCRIPTION
## What
Fixes `TEXT()` / number formatting to match Excel across three issues found via the ingestion source-error loop:
- **Percent token** scales the value by 100 (`TEXT(0.05,"0%")` → `5%`).
- **Excel rounding** (15 significant digits, half-away-from-zero).
- **Multi-section formats** (`positive;negative;zero;text`): split at top level (quote/escape aware), select the sign-appropriate section, then dispatch it through date → duration → number formatters. Pure-text sections (e.g. accounting `"-"` for zero) render as display text.

## Why
The vendored engine emitted e.g. `506%;(0)%` where Excel stored `5%`, producing ~dozens of false source errors per model when ingesting whole models (which store formulas).

## Tests
`jest test/format test/interpreter/function-text.spec.ts` — 43 pass, incl. new multi-section date-section and pure-text-section cases.

Part of a 4-repo source-error fix (common / source-error-lambda / ingestion-service).