### PR TITLE
docs(parser): fix misplaced OFFSET JSDoc + escaped-quote comment wording

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"

--- a/src/parser/FormulaParser.ts
+++ b/src/parser/FormulaParser.ts
@@ -751,11 +751,6 @@ export class FormulaParser extends EmbeddedActionsParser {
   }
 
   /**
-   * Returns {@link CellReferenceAst} or {@link CellRangeAst} based on OFFSET function arguments
-   *
-   * @param {Ast[]} args - OFFSET function arguments
-   */
-  /**
    * Resolves an OFFSET shift/size argument to a static integer at parse time. Accepts a number literal,
    * a unary +/- number, and COLUMNS/ROWS of a literal range (both are compile-time constants — the width
    * / height of a fixed range). Returns null when the argument is not statically resolvable.
@@ -785,6 +780,11 @@ export class FormulaParser extends EmbeddedActionsParser {
     return null
   }
 
+  /**
+   * Returns {@link CellReferenceAst} or {@link CellRangeAst} based on OFFSET function arguments
+   *
+   * @param {Ast[]} args - OFFSET function arguments
+   */
   private handleOffsetHeuristic(args: Ast[]): Ast {
     // Excel's OFFSET accepts either a single cell or a range as its base. For a range, offsets apply to
     // its top-left corner and omitted height/width default to the range's own dimensions (not 1).

--- a/src/parser/LexerConfig.ts
+++ b/src/parser/LexerConfig.ts
@@ -42,7 +42,7 @@ export const ArrayLParen = createToken({name: 'ArrayLParen', pattern: /{/})
 export const ArrayRParen = createToken({name: 'ArrayRParen', pattern: /}/})
 
 // Excel escapes a double-quote inside a string literal by doubling it ("a""b" is the value a"b), so the
-// token allows "" between the delimiters; buildStringAst collapses each "" back to a single quote.
+// token allows "" between the delimiters; buildStringAst collapses each "" back to a single double-quote.
 export const StringLiteral = createToken({name: 'StringLiteral', pattern: /"([^"]*(""[^"]*)*)"/})
 export const ErrorLiteral = createToken({name: 'ErrorLiteral', pattern: new RegExp(`(${SHEET_NAME_PATTERN})?#[A-Za-z0-9\\/]+[?!]?`)})
 


### PR DESCRIPTION
Follow-up to #31 addressing the two Copilot review comments (which landed after merge):
- `handleOffsetHeuristic`'s JSDoc had floated above the newly-inserted `staticIntegerArg`; moved it back so both methods are documented correctly.
- `LexerConfig`: the comment said `""` collapses to a 'single quote'; it collapses to a single **double**-quote. Clarified.

Doc-only; v0.0.18.