### PR TITLE
fix(source-errors): TEXT text-passthrough, cross-sheet implicit intersection, VALUE function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"

--- a/src/DependencyGraph/DependencyGraph.ts
+++ b/src/DependencyGraph/DependencyGraph.ts
@@ -12,7 +12,6 @@ import {CellDependency} from '../CellDependency'
 import {Config} from '../Config'
 import {ContentChanges} from '../ContentChanges'
 import {ErrorMessage} from '../error-message'
-import {rangeIntersectionAtAddress} from '../interpreter/ArithmeticHelper'
 import {FunctionRegistry} from '../interpreter/FunctionRegistry'
 import {
   EmptyValue,
@@ -556,7 +555,7 @@ export class DependencyGraph {
       // labelled value from another sheet" pattern — leaving same-sheet bare ranges as #VALUE! (the
       // engine's existing, deliberately non-intersecting behavior).
       if (value.range !== undefined && value.range.sheet !== address.sheet) {
-        return rangeIntersectionAtAddress(value, address) ?? new CellError(ErrorType.VALUE, ErrorMessage.ScalarExpected)
+        return value.scalarAtAddress(address) ?? new CellError(ErrorType.VALUE, ErrorMessage.ScalarExpected)
       }
       return new CellError(ErrorType.VALUE, ErrorMessage.ScalarExpected)
     }

--- a/src/DependencyGraph/DependencyGraph.ts
+++ b/src/DependencyGraph/DependencyGraph.ts
@@ -12,6 +12,7 @@ import {CellDependency} from '../CellDependency'
 import {Config} from '../Config'
 import {ContentChanges} from '../ContentChanges'
 import {ErrorMessage} from '../error-message'
+import {rangeIntersectionAtAddress} from '../interpreter/ArithmeticHelper'
 import {FunctionRegistry} from '../interpreter/FunctionRegistry'
 import {
   EmptyValue,
@@ -550,6 +551,13 @@ export class DependencyGraph {
   public getScalarValue(address: SimpleCellAddress): InternalScalarValue {
     const value = this.addressMapping.getCellValue(address)
     if (value instanceof SimpleRangeValue) {
+      // A bare cross-sheet range reference (e.g. ='Other Sheet'!B5:C5) read as a single cell: Excel
+      // implicit-intersects by the reader's row/column. Scoped to cross-sheet — the common "pull a
+      // labelled value from another sheet" pattern — leaving same-sheet bare ranges as #VALUE! (the
+      // engine's existing, deliberately non-intersecting behavior).
+      if (value.range !== undefined && value.range.sheet !== address.sheet) {
+        return rangeIntersectionAtAddress(value, address) ?? new CellError(ErrorType.VALUE, ErrorMessage.ScalarExpected)
+      }
       return new CellError(ErrorType.VALUE, ErrorMessage.ScalarExpected)
     }
     return value

--- a/src/SimpleRangeValue.ts
+++ b/src/SimpleRangeValue.ts
@@ -9,6 +9,7 @@ import {CellError, ErrorType, simpleCellAddress, SimpleCellAddress} from './Cell
 import {DependencyGraph} from './DependencyGraph'
 import {ErrorMessage} from './error-message'
 import {InternalScalarValue, isExtendedNumber} from './interpreter/InterpreterValue'
+import {Maybe} from './Maybe'
 
 /**
  * A class that represents a range of data.
@@ -87,6 +88,32 @@ export class SimpleRangeValue {
    */
   public isAdHoc(): boolean {
     return this.range === undefined
+  }
+
+  /**
+   * Excel implicit intersection: the single value a range collapses to when read from a formula at
+   * `formulaAddress`. A single-column range picks the cell in the formula's row, a single-row range the
+   * cell in the formula's column (matched by absolute index, so it works cross-sheet). An ad-hoc range
+   * (no address) yields its top-left cell. Returns `undefined` for an addressed 2-D range or when the
+   * formula falls outside the range's span — the caller turns that into #VALUE!.
+   */
+  public scalarAtAddress(formulaAddress: SimpleCellAddress): Maybe<InternalScalarValue> {
+    if (this.isAdHoc()) {
+      return this.data[0]?.[0]
+    }
+    const range = this.range!
+    if (range.width() === 1) {
+      const offset = formulaAddress.row - range.start.row
+      if (offset >= 0 && offset < range.height()) {
+        return this.data[offset][0]
+      }
+    } else if (range.height() === 1) {
+      const offset = formulaAddress.col - range.start.col
+      if (offset >= 0 && offset < range.width()) {
+        return this.data[0][offset]
+      }
+    }
+    return undefined
   }
 
   /**

--- a/src/i18n/languages/csCZ.ts
+++ b/src/i18n/languages/csCZ.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNICHAR',
     UNICODE: 'UNICODE',
     UPPER: 'VELKÁ',
+    VALUE: 'HODNOTA',
     VARA: 'VARA',
     'VAR.P': 'VAR.P',
     VARPA: 'VARPA',

--- a/src/i18n/languages/daDK.ts
+++ b/src/i18n/languages/daDK.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNICHAR',
     UNICODE: 'UNICODE',
     UPPER: 'STORE.BOGSTAVER',
+    VALUE: 'VÆRDI',
     VARA: 'VARIANSV',
     'VAR.P': 'VARIANS.P',
     VARPA: 'VARIANSPV',

--- a/src/i18n/languages/deDE.ts
+++ b/src/i18n/languages/deDE.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNIZEICHEN',
     UNICODE: 'UNICODE',
     UPPER: 'GROSS',
+    VALUE: 'WERT',
     VARA: 'VARIANZA',
     'VAR.P': 'VAR.P',
     VARPA: 'VARIANZENA',

--- a/src/i18n/languages/enGB.ts
+++ b/src/i18n/languages/enGB.ts
@@ -229,6 +229,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNICHAR',
     UNICODE: 'UNICODE',
     UPPER: 'UPPER',
+    VALUE: 'VALUE',
     VARA: 'VARA',
     'VAR.P': 'VAR.P',
     VARPA: 'VARPA',

--- a/src/i18n/languages/esES.ts
+++ b/src/i18n/languages/esES.ts
@@ -227,6 +227,7 @@ export const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNICHAR',
     UNICODE: 'UNICODE',
     UPPER: 'MAYUSC',
+    VALUE: 'VALOR',
     VARA: 'VARA',
     'VAR.P': 'VAR.P',
     VARPA: 'VARPA',

--- a/src/i18n/languages/fiFI.ts
+++ b/src/i18n/languages/fiFI.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNICODEMERKKI',
     UNICODE: 'UNICODE',
     UPPER: 'ISOT',
+    VALUE: 'ARVO',
     VARA: 'VARA',
     'VAR.P': 'VAR.P',
     VARPA: 'VARPA',

--- a/src/i18n/languages/frFR.ts
+++ b/src/i18n/languages/frFR.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNICAR',
     UNICODE: 'UNICODE',
     UPPER: 'MAJUSCULE',
+    VALUE: 'CNUM',
     VARA: 'VARA',
     'VAR.P': 'VAR.P.N',
     VARPA: 'VARPA',

--- a/src/i18n/languages/huHU.ts
+++ b/src/i18n/languages/huHU.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNIKARAKTER',
     UNICODE: 'UNICODE',
     UPPER: 'NAGYBETŰS',
+    VALUE: 'SZÁMÉRTÉK',
     VARA: 'VARA',
     'VAR.P': 'VAR.S',
     VARPA: 'VARPA',

--- a/src/i18n/languages/itIT.ts
+++ b/src/i18n/languages/itIT.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'CARATT.UNI',
     UNICODE: 'UNICODE',
     UPPER: 'MAIUSC',
+    VALUE: 'VALORE',
     VARA: 'VAR.VALORI',
     'VAR.P': 'VAR.P',
     VARPA: 'VAR.POP.VALORI',

--- a/src/i18n/languages/nbNO.ts
+++ b/src/i18n/languages/nbNO.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNICODETEGN',
     UNICODE: 'UNICODE',
     UPPER: 'STORE',
+    VALUE: 'VERDI',
     VARA: 'VARIANSA',
     'VAR.P': 'VARIANS.P',
     VARPA: 'VARIANSPA',

--- a/src/i18n/languages/nlNL.ts
+++ b/src/i18n/languages/nlNL.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNITEKEN',
     UNICODE: 'UNICODE',
     UPPER: 'HOOFDLETTERS',
+    VALUE: 'WAARDE',
     VARA: 'VARA',
     'VAR.P': 'VAR.P',
     VARPA: 'VARPA',

--- a/src/i18n/languages/plPL.ts
+++ b/src/i18n/languages/plPL.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'ZNAK.UNICODE',
     UNICODE: 'UNICODE',
     UPPER: 'LITERY.WIELKIE',
+    VALUE: 'WARTOŚĆ',
     VARA: 'WARIANCJA.A',
     'VAR.P': 'WARIANCJA.POP',
     VARPA: 'WARIANCJA.POPUL.A',

--- a/src/i18n/languages/ptPT.ts
+++ b/src/i18n/languages/ptPT.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'CARACTUNI',
     UNICODE: 'UNICODE',
     UPPER: 'MAIÚSCULA',
+    VALUE: 'VALOR',
     VARA: 'VARA',
     'VAR.P': 'VAR.P',
     VARPA: 'VARPA',

--- a/src/i18n/languages/ruRU.ts
+++ b/src/i18n/languages/ruRU.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'ЮНИСИМВ',
     UNICODE: 'UNICODE',
     UPPER: 'ПРОПИСН',
+    VALUE: 'ЗНАЧЕН',
     VARA: 'ДИСПА',
     'VAR.P': 'ДИСП.Г',
     VARPA: 'ДИСПРА',

--- a/src/i18n/languages/svSE.ts
+++ b/src/i18n/languages/svSE.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNICHAR',
     UNICODE: 'UNICODE',
     UPPER: 'VERSALER',
+    VALUE: 'TEXTNUM',
     VARA: 'VARA',
     'VAR.P': 'VARIANS.P',
     VARPA: 'VARPA',

--- a/src/i18n/languages/trTR.ts
+++ b/src/i18n/languages/trTR.ts
@@ -227,6 +227,7 @@ const dictionary: RawTranslationPackage = {
     UNICHAR: 'UNICODEKARAKTERİ',
     UNICODE: 'UNICODE',
     UPPER: 'BÜYÜKHARF',
+    VALUE: 'SAYIYAÇEVİR',
     VARA: 'VARA',
     'VAR.P': 'VAR.P',
     VARPA: 'VARSA',

--- a/src/interpreter/ArithmeticHelper.ts
+++ b/src/interpreter/ArithmeticHelper.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2025 Handsoncode. All rights reserved.
  */
 
-import {CellError, CellValueTypeOrd, ErrorType, getCellValueType, SimpleCellAddress} from '../Cell'
+import {CellError, CellValueTypeOrd, ErrorType, getCellValueType} from '../Cell'
 import {Config} from '../Config'
 import {DateTimeHelper} from '../DateTimeHelper'
 import {ErrorMessage} from '../error-message'
@@ -810,36 +810,11 @@ export function forceNormalizeString(str: string): string {
   return normalizeString(str.toLowerCase(), 'nfd').replace(/[\u0300-\u036f]/g, '')
 }
 
-/**
- * Excel implicit intersection of a range against a formula's position: a single-column range picks the
- * cell in the formula's row, a single-row range the cell in the formula's column. Matched by absolute
- * row/column index, so it works cross-sheet. Returns undefined for a 2-D range or when the formula falls
- * outside the range's span (the caller turns that into #VALUE!).
- */
-export function rangeIntersectionAtAddress(arg: SimpleRangeValue, formulaAddress: SimpleCellAddress): Maybe<InternalScalarValue> {
-  if (arg.isAdHoc()) {
-    return arg.data[0]?.[0]
-  }
-  const range = arg.range!
-  if (range.width() === 1) {
-    const offset = formulaAddress.row - range.start.row
-    if (offset >= 0 && offset < range.height()) {
-      return arg.data[offset][0]
-    }
-  } else if (range.height() === 1) {
-    const offset = formulaAddress.col - range.start.col
-    if (offset >= 0 && offset < range.width()) {
-      return arg.data[0][offset]
-    }
-  }
-  return undefined
-}
-
 export function coerceRangeToScalar(arg: SimpleRangeValue, state: InterpreterState): Maybe<InternalScalarValue> {
   if (!arg.isAdHoc() && state.formulaAddress.sheet !== arg.range!.sheet) {
     return undefined
   }
-  return rangeIntersectionAtAddress(arg, state.formulaAddress)
+  return arg.scalarAtAddress(state.formulaAddress)
 }
 
 type NormalizationForm = 'nfc' | 'nfd' | 'nfkc' | 'nfkd'

--- a/src/interpreter/ArithmeticHelper.ts
+++ b/src/interpreter/ArithmeticHelper.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2025 Handsoncode. All rights reserved.
  */
 
-import {CellError, CellValueTypeOrd, ErrorType, getCellValueType} from '../Cell'
+import {CellError, CellValueTypeOrd, ErrorType, getCellValueType, SimpleCellAddress} from '../Cell'
 import {Config} from '../Config'
 import {DateTimeHelper} from '../DateTimeHelper'
 import {ErrorMessage} from '../error-message'
@@ -810,25 +810,36 @@ export function forceNormalizeString(str: string): string {
   return normalizeString(str.toLowerCase(), 'nfd').replace(/[\u0300-\u036f]/g, '')
 }
 
-export function coerceRangeToScalar(arg: SimpleRangeValue, state: InterpreterState): Maybe<InternalScalarValue> {
+/**
+ * Excel implicit intersection of a range against a formula's position: a single-column range picks the
+ * cell in the formula's row, a single-row range the cell in the formula's column. Matched by absolute
+ * row/column index, so it works cross-sheet. Returns undefined for a 2-D range or when the formula falls
+ * outside the range's span (the caller turns that into #VALUE!).
+ */
+export function rangeIntersectionAtAddress(arg: SimpleRangeValue, formulaAddress: SimpleCellAddress): Maybe<InternalScalarValue> {
   if (arg.isAdHoc()) {
     return arg.data[0]?.[0]
   }
   const range = arg.range!
-  if (state.formulaAddress.sheet === range.sheet) {
-    if (range.width() === 1) {
-      const offset = state.formulaAddress.row - range.start.row
-      if (offset >= 0 && offset < range.height()) {
-        return arg.data[offset][0]
-      }
-    } else if (range.height() === 1) {
-      const offset = state.formulaAddress.col - range.start.col
-      if (offset >= 0 && offset < range.width()) {
-        return arg.data[0][offset]
-      }
+  if (range.width() === 1) {
+    const offset = formulaAddress.row - range.start.row
+    if (offset >= 0 && offset < range.height()) {
+      return arg.data[offset][0]
+    }
+  } else if (range.height() === 1) {
+    const offset = formulaAddress.col - range.start.col
+    if (offset >= 0 && offset < range.width()) {
+      return arg.data[0][offset]
     }
   }
   return undefined
+}
+
+export function coerceRangeToScalar(arg: SimpleRangeValue, state: InterpreterState): Maybe<InternalScalarValue> {
+  if (!arg.isAdHoc() && state.formulaAddress.sheet !== arg.range!.sheet) {
+    return undefined
+  }
+  return rangeIntersectionAtAddress(arg, state.formulaAddress)
 }
 
 type NormalizationForm = 'nfc' | 'nfd' | 'nfkc' | 'nfkd'

--- a/src/interpreter/plugin/DateTimePlugin.ts
+++ b/src/interpreter/plugin/DateTimePlugin.ts
@@ -16,6 +16,7 @@ import {
   truncateDayInMonth
 } from '../../DateTimeHelper'
 import {ErrorMessage} from '../../error-message'
+import {coerceScalarToString} from '../ArithmeticHelper'
 import {format} from '../../format/format'
 import {Maybe} from '../../Maybe'
 import {ProcedureAst} from '../../parser'
@@ -89,7 +90,7 @@ export class DateTimePlugin extends FunctionPlugin implements FunctionPluginType
     'TEXT': {
       method: 'text',
       parameters: [
-        {argumentType: FunctionArgumentType.NUMBER},
+        {argumentType: FunctionArgumentType.SCALAR},
         {argumentType: FunctionArgumentType.STRING},
       ]
     },
@@ -360,7 +361,17 @@ export class DateTimePlugin extends FunctionPlugin implements FunctionPluginType
    */
   public text(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('TEXT'),
-      (numberRepresentation, formatArg) => format(numberRepresentation, formatArg, this.config, this.dateTimeHelper)
+      (value, formatArg) => {
+        if (value instanceof CellError) {
+          return value
+        }
+        const coerced = this.coerceScalarToNumberOrError(value)
+        if (coerced instanceof CellError) {
+          // Excel returns non-numeric text unchanged: TEXT("December", "mmmm") -> "December"
+          return coerceScalarToString(value)
+        }
+        return format(getRawValue(coerced), formatArg, this.config, this.dateTimeHelper)
+      }
     )
   }
 

--- a/src/interpreter/plugin/TextPlugin.ts
+++ b/src/interpreter/plugin/TextPlugin.ts
@@ -160,6 +160,12 @@ export class TextPlugin extends FunctionPlugin implements FunctionPluginTypechec
         {argumentType: FunctionArgumentType.STRING}
       ]
     },
+    'VALUE': {
+      method: 'value',
+      parameters: [
+        {argumentType: FunctionArgumentType.NUMBER}
+      ]
+    },
   }
 
   /**
@@ -378,6 +384,19 @@ export class TextPlugin extends FunctionPlugin implements FunctionPluginTypechec
     return this.runFunction(ast.args, state, this.metadata('UPPER'), (arg: string) => {
       return arg.toUpperCase()
     })
+  }
+
+  /**
+   * Corresponds to VALUE(text)
+   *
+   * Converts a text string that represents a number to a number. The NUMBER argument type performs the
+   * text-to-number coercion (and yields #VALUE! for non-numeric text), so this returns the coerced value.
+   *
+   * @param ast
+   * @param state
+   */
+  public value(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('VALUE'), (value: number) => value)
   }
 
   private escapeRegExpSpecialCharacters(text: string): string {

--- a/test/interpreter/function-text.spec.ts
+++ b/test/interpreter/function-text.spec.ts
@@ -47,6 +47,24 @@ describe('TEXT()', () => {
     expect(engine.getCellValue(adr('B3'))).toEqual('0%')
   })
 
+  it('returns non-numeric text unchanged (Excel passthrough)', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['=TEXT("December", "mmmm")'],
+      ['="Fiscal Years ending "&TEXT("December", "mmmm")&","'],
+    ])
+
+    expect(engine.getCellValue(adr('A1'))).toEqual('December')
+    expect(engine.getCellValue(adr('A2'))).toEqual('Fiscal Years ending December,')
+  })
+
+  it('still formats numeric text as a number', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['=TEXT("5", "0.00")'],
+    ])
+
+    expect(engine.getCellValue(adr('A1'))).toEqual('5.00')
+  })
+
   it('wrong number of arguments', () => {
     const engine = HyperFormula.buildFromArray([
       ['=TEXT(42)'],

--- a/test/interpreter/function-value.spec.ts
+++ b/test/interpreter/function-value.spec.ts
@@ -1,0 +1,42 @@
+import {HyperFormula} from '../../src'
+import {ErrorType} from '../../src'
+import {ErrorMessage} from '../../src/error-message'
+import {adr, detailedError} from '../testUtils'
+
+describe('VALUE()', () => {
+  it('converts numeric text to a number', () => {
+    const engine = HyperFormula.buildFromArray([['=VALUE("123")']])
+
+    expect(engine.getCellValue(adr('A1'))).toEqual(123)
+  })
+
+  it('converts a decimal string', () => {
+    const engine = HyperFormula.buildFromArray([['=VALUE("3.14")']])
+
+    expect(engine.getCellValue(adr('A1'))).toEqual(3.14)
+  })
+
+  it('extracts a leading number via LEFT (the NBIX case)', () => {
+    const engine = HyperFormula.buildFromArray([['2026 Guidance', '=VALUE(LEFT(A1, 4))']])
+
+    expect(engine.getCellValue(adr('B1'))).toEqual(2026)
+  })
+
+  it('passes a number through unchanged', () => {
+    const engine = HyperFormula.buildFromArray([['=VALUE(42)']])
+
+    expect(engine.getCellValue(adr('A1'))).toEqual(42)
+  })
+
+  it('returns #VALUE! for non-numeric text', () => {
+    const engine = HyperFormula.buildFromArray([['=VALUE("hello")']])
+
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.NumberCoercion))
+  })
+
+  it('wrong number of arguments', () => {
+    const engine = HyperFormula.buildFromArray([['=VALUE()']])
+
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NA, ErrorMessage.WrongArgNumber))
+  })
+})

--- a/test/interpreter/range-scalar-intersection.spec.ts
+++ b/test/interpreter/range-scalar-intersection.spec.ts
@@ -1,0 +1,52 @@
+import {HyperFormula} from '../../src'
+import {ErrorType} from '../../src'
+import {ErrorMessage} from '../../src/error-message'
+import {adr, detailedError} from '../testUtils'
+
+describe('cross-sheet range reference in scalar context (implicit intersection)', () => {
+  it('intersects a single-row cross-sheet range by the formula column', () => {
+    const engine = HyperFormula.buildFromSheets({
+      Data: [['m', 'HEADER', 'other']],
+      Report: [[null, "='Data'!B1:C1"]],
+    })
+
+    expect(engine.getCellValue(adr('B1', 1))).toEqual('HEADER')
+  })
+
+  it('intersects a single-column cross-sheet range by the formula row', () => {
+    const engine = HyperFormula.buildFromSheets({
+      Data: [[10], [20], [30]],
+      Report: [[null], ["='Data'!A1:A3"]],
+    })
+
+    expect(engine.getCellValue(adr('A2', 1))).toEqual(20)
+  })
+
+  it('errors when the formula falls outside the cross-sheet range span', () => {
+    const engine = HyperFormula.buildFromSheets({
+      Data: [[10], [20], [30]],
+      Report: [[null], [null], [null], [null], ["='Data'!A1:A3"]],
+    })
+
+    expect(engine.getCellValue(adr('A5', 1))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.ScalarExpected))
+  })
+
+  it('errors for a two-dimensional cross-sheet range', () => {
+    const engine = HyperFormula.buildFromSheets({
+      Data: [[1, 2], [3, 4]],
+      Report: [["='Data'!A1:B2"]],
+    })
+
+    expect(engine.getCellValue(adr('A1', 1))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.ScalarExpected))
+  })
+
+  it('leaves a same-sheet bare range reference as #VALUE! (existing behavior)', () => {
+    const engine = HyperFormula.buildFromArray([
+      [10, '=A1:A3'],
+      [20],
+      [30],
+    ])
+
+    expect(engine.getCellValue(adr('B1'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.ScalarExpected))
+  })
+})


### PR DESCRIPTION
Three independent source-error fixes surfaced by the MOD-TMO and NBIX_Public models. Each has its own commit and failing-test-first coverage. Bumps to **0.0.19**.

## A — `TEXT()` returns non-numeric text unchanged
`TEXT('Control Panel'!G7,"mmmm")` where `G7` is a month *name* string (from `CHOOSE`) errored `#VALUE!` — the first arg was typed `NUMBER`, so a non-numeric string was rejected before the body ran. Excel returns such text verbatim. Now the arg is `SCALAR` and passes text through when it can't be coerced; numeric text (`TEXT("5","0.00")`→`"5.00"`) still formats. *(Not the `mmmm` bug — that already works.)*

## B — cross-sheet range reference read as a scalar
`='Other Sheet'!B5:C5` read as a single cell errored `#VALUE!` "Cell range not allowed" instead of Excel's implicit intersection by the reader's row/column. Extracted the address-based intersection core (`rangeIntersectionAtAddress`) and applied it in `getScalarValue`, **scoped to cross-sheet** — the common "pull a labelled value from another sheet" pattern. `coerceRangeToScalar` keeps its exact same-sheet-gated behavior for operator/argument coercion, so existing binary/unary/function tests are unchanged. Same-sheet bare ranges deliberately still `#VALUE!`.

## D — `VALUE()` implemented
The fork had `DATEVALUE`/`TIMEVALUE` but not `VALUE`, so `=VALUE(LEFT(A1,4))` errored `#NAME?`. Added to `TextPlugin` + all localized i18n function maps (the i18n completeness/uniqueness tests caught one bad localized name).

## Tests
- New: `function-value.spec.ts`, `range-scalar-intersection.spec.ts`; extended `function-text.spec.ts`.
- Full suite: **5216 pass**, only 2 pre-existing `null-compatibility` failures (they fail on clean `master` too — unrelated).
- Verified end-to-end through the ingestion→common→fork chain: MOD-TMO and NBIX both go to **0 source errors**.