### PR TITLE
feat: fork function batch — XNPV, INTERCEPT, VSTACK, realPow, MATCH, date parsing [0.0.22]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"

--- a/src/DateTimeDefault.ts
+++ b/src/DateTimeDefault.ts
@@ -150,7 +150,9 @@ function defaultParseToDate(dateItems: string[], dateFormat: Maybe<string>): May
     return undefined
   }
 
-  const day = Number(dateItems[dayItem])
+  // A format without a day component (e.g. "MM/YYYY") defaults the day to 1, matching how Excel parses a
+  // month/year string such as "02/2014" into 1 Feb 2014 (month + year still required, below).
+  const day = dayItem === -1 ? 1 : Number(dateItems[dayItem])
   if (!(Number.isFinite(day) && Number.isInteger(day))) {
     return undefined
   }

--- a/src/error-message.ts
+++ b/src/error-message.ts
@@ -28,6 +28,7 @@ export class ErrorMessage {
   public static OutOfSheet = 'Resulting reference is out of the sheet.'
   public static WrongType = 'Wrong type of argument.'
   public static NaN = 'NaN or infinite value encountered.'
+  public static NoConvergence = 'Iteration did not converge to a result.'
   public static EqualLength = 'Ranges need to be of equal length.'
   public static Negative = 'Value cannot be negative.'
   public static NotBinary = 'String does not represent a binary number.'

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -130,6 +130,15 @@ function renderFormatLiteral(text: string): string {
       ++i
       continue
     }
+    // `_x` reserves space the width of the next character (used for alignment, e.g. "0.0_)"); render
+    // it as a single space and skip the width char, rather than leaking `_)` into the output.
+    if (ch === '_') {
+      result += ' '
+      if (i + 1 < text.length) {
+        ++i
+      }
+      continue
+    }
     if (ch === '"') {
       continue
     }

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -123,8 +123,19 @@ function countChars(text: string, char: string) {
  * delimiters, leaving the display text (e.g. `\%` and `"%"` both render as `%`). */
 function renderFormatLiteral(text: string): string {
   let result = ''
+  let inQuote = false
   for (let i = 0; i < text.length; ++i) {
     const ch = text[i]
+    // Inside a quoted literal every character is verbatim — `_`, `\`, etc. are NOT format tokens there
+    // (Excel: "a_b" renders "a_b", not "a b"). The quote chars themselves are consumed.
+    if (ch === '"') {
+      inQuote = !inQuote
+      continue
+    }
+    if (inQuote) {
+      result += ch
+      continue
+    }
     if (ch === '\\' && i + 1 < text.length) {
       result += text[i + 1]
       ++i
@@ -137,9 +148,6 @@ function renderFormatLiteral(text: string): string {
       if (i + 1 < text.length) {
         ++i
       }
-      continue
-    }
-    if (ch === '"') {
       continue
     }
     result += ch

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -171,7 +171,7 @@ function countPercentSigns(tokens: FormatToken[]): number {
  * avoids re-introducing floating-point noise. ponytail: values >= 1e15 have no meaningful
  * fractional digits in a double, so skip the shift (whose `e`-notation string would break) and
  * return them unchanged. */
-function roundHalfAwayFromZero(value: number, decimals: number): number {
+export function roundHalfAwayFromZero(value: number, decimals: number): number {
   if (!isFinite(value) || Math.abs(value) >= 1e15) {
     return value
   }

--- a/src/i18n/languages/csCZ.ts
+++ b/src/i18n/languages/csCZ.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#HODNOTA!',
   },
   functions: {
+    'RANK.AVG': 'POŘADÍ.PRŮMĚR',
+    NUMBERVALUE: 'ČÍSELNÁHODNOTA',
     IRR: 'MÍRA.VÝNOSNOSTI',
     FIXED: 'ZAOKROUHLIT.NA.TEXT',
     FILTER: 'FILTER',

--- a/src/i18n/languages/csCZ.ts
+++ b/src/i18n/languages/csCZ.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#HODNOTA!',
   },
   functions: {
+    IRR: 'MÍRA.VÝNOSNOSTI',
+    FIXED: 'ZAOKROUHLIT.NA.TEXT',
     FILTER: 'FILTER',
     ADDRESS: 'ODKAZ',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/csCZ.ts
+++ b/src/i18n/languages/csCZ.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#HODNOTA!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'POŘADÍ.PRŮMĚR',
     NUMBERVALUE: 'ČÍSELNÁHODNOTA',
     IRR: 'MÍRA.VÝNOSNOSTI',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'FTEST',
     STEYX: 'STEYX',
     SLOPE: 'SLOPE',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'COVAR',
     'COVARIANCE.P': 'COVARIANCE.P',
     'COVARIANCE.S': 'COVARIANCE.S',

--- a/src/i18n/languages/daDK.ts
+++ b/src/i18n/languages/daDK.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VÆRDI!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'PLADS.GNSN',
     NUMBERVALUE: 'TALVÆRDI',
     IRR: 'IA',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'FTEST',
     STEYX: 'STFYX',
     SLOPE: 'STIGNING',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'KOVARIANS',
     'COVARIANCE.P': 'KOVARIANS.P',
     'COVARIANCE.S': 'KOVARIANS.S',

--- a/src/i18n/languages/daDK.ts
+++ b/src/i18n/languages/daDK.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VÆRDI!',
   },
   functions: {
+    'RANK.AVG': 'PLADS.GNSN',
+    NUMBERVALUE: 'TALVÆRDI',
     IRR: 'IA',
     FIXED: 'FAST',
     FILTER: 'FILTER',

--- a/src/i18n/languages/daDK.ts
+++ b/src/i18n/languages/daDK.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VÆRDI!',
   },
   functions: {
+    IRR: 'IA',
+    FIXED: 'FAST',
     FILTER: 'FILTER',
     ADDRESS: 'ADRESSE',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/deDE.ts
+++ b/src/i18n/languages/deDE.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#WERT!',
   },
   functions: {
+    IRR: 'IKV',
+    FIXED: 'FEST',
     FILTER: 'FILTER',
     ADDRESS: 'ADRESSE',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/deDE.ts
+++ b/src/i18n/languages/deDE.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#WERT!',
   },
   functions: {
+    'RANK.AVG': 'RANG.MITTELW',
+    NUMBERVALUE: 'ZAHLENWERT',
     IRR: 'IKV',
     FIXED: 'FEST',
     FILTER: 'FILTER',

--- a/src/i18n/languages/deDE.ts
+++ b/src/i18n/languages/deDE.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#WERT!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'RANG.MITTELW',
     NUMBERVALUE: 'ZAHLENWERT',
     IRR: 'IKV',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'FTEST',
     STEYX: 'STFEHLERYX',
     SLOPE: 'STEIGUNG',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'KOVAR',
     'COVARIANCE.P': 'KOVARIANZ.P',
     'COVARIANCE.S': 'KOVARIANZ.S',

--- a/src/i18n/languages/enGB.ts
+++ b/src/i18n/languages/enGB.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALUE!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'RANK.AVG',
     NUMBERVALUE: 'NUMBERVALUE',
     IRR: 'IRR',
@@ -394,6 +396,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'FTEST',
     STEYX: 'STEYX',
     SLOPE: 'SLOPE',
+    INTERCEPT: 'INTERCEPT',
     'CHISQ.TEST': 'CHISQ.TEST',
     CHITEST: 'CHITEST',
     'T.TEST': 'T.TEST',

--- a/src/i18n/languages/enGB.ts
+++ b/src/i18n/languages/enGB.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALUE!',
   },
   functions: {
+    'RANK.AVG': 'RANK.AVG',
+    NUMBERVALUE: 'NUMBERVALUE',
     IRR: 'IRR',
     FIXED: 'FIXED',
     FILTER: 'FILTER',

--- a/src/i18n/languages/enGB.ts
+++ b/src/i18n/languages/enGB.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALUE!',
   },
   functions: {
+    IRR: 'IRR',
+    FIXED: 'FIXED',
     FILTER: 'FILTER',
     ADDRESS: 'ADDRESS',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/esES.ts
+++ b/src/i18n/languages/esES.ts
@@ -18,6 +18,8 @@ export const dictionary: RawTranslationPackage = {
     VALUE: '#¡VALOR!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'JERARQUIA.MEDIA',
     NUMBERVALUE: 'VALORNÚMERO',
     IRR: 'TIR',
@@ -391,6 +393,7 @@ export const dictionary: RawTranslationPackage = {
     FTEST: 'PRUEBA.F',
     STEYX: 'ERROR.TIPICO.XY',
     SLOPE: 'PENDIENTE',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'COVAR',
     'COVARIANCE.P': 'COVARIANCE.P',
     'COVARIANCE.S': 'COVARIANZA.M',

--- a/src/i18n/languages/esES.ts
+++ b/src/i18n/languages/esES.ts
@@ -18,6 +18,8 @@ export const dictionary: RawTranslationPackage = {
     VALUE: '#¡VALOR!',
   },
   functions: {
+    IRR: 'TIR',
+    FIXED: 'DECIMAL',
     FILTER: 'FILTER',
     ADDRESS: 'DIRECCION',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/esES.ts
+++ b/src/i18n/languages/esES.ts
@@ -18,6 +18,8 @@ export const dictionary: RawTranslationPackage = {
     VALUE: '#¡VALOR!',
   },
   functions: {
+    'RANK.AVG': 'JERARQUIA.MEDIA',
+    NUMBERVALUE: 'VALORNÚMERO',
     IRR: 'TIR',
     FIXED: 'DECIMAL',
     FILTER: 'FILTER',

--- a/src/i18n/languages/fiFI.ts
+++ b/src/i18n/languages/fiFI.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ARVO!',
   },
   functions: {
+    'RANK.AVG': 'ARVON.MUKAAN.KESKIARVO',
+    NUMBERVALUE: 'NUMEROARVO',
     IRR: 'SISÄINEN.KORKO',
     FIXED: 'KIINTEÄ',
     FILTER: 'FILTER',

--- a/src/i18n/languages/fiFI.ts
+++ b/src/i18n/languages/fiFI.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ARVO!',
   },
   functions: {
+    IRR: 'SISÄINEN.KORKO',
+    FIXED: 'KIINTEÄ',
     FILTER: 'FILTER',
     ADDRESS: 'OSOITE',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/fiFI.ts
+++ b/src/i18n/languages/fiFI.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ARVO!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'ARVON.MUKAAN.KESKIARVO',
     NUMBERVALUE: 'NUMEROARVO',
     IRR: 'SISÄINEN.KORKO',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'FTESTI',
     STEYX: 'KESKIVIRHE',
     SLOPE: 'KULMAKERROIN',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'KOVARIANSSI',
     'COVARIANCE.P': 'KOVARIANSSI.P',
     'COVARIANCE.S': 'KOVARIANSSI.S',

--- a/src/i18n/languages/frFR.ts
+++ b/src/i18n/languages/frFR.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALEUR!',
   },
   functions: {
+    'RANK.AVG': 'MOYENNE.RANG',
+    NUMBERVALUE: 'VALEURNOMBRE',
     IRR: 'TRI',
     FIXED: 'CTXT',
     FILTER: 'FILTER',

--- a/src/i18n/languages/frFR.ts
+++ b/src/i18n/languages/frFR.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALEUR!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'MOYENNE.RANG',
     NUMBERVALUE: 'VALEURNOMBRE',
     IRR: 'TRI',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'TEST.F',
     STEYX: 'ERREUR.TYPE.XY',
     SLOPE: 'PENTE',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'COVARIANCE',
     'COVARIANCE.P': 'COVARIANCE.PEARSON',
     'COVARIANCE.S': 'COVARIANCE.STANDARD',

--- a/src/i18n/languages/frFR.ts
+++ b/src/i18n/languages/frFR.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALEUR!',
   },
   functions: {
+    IRR: 'TRI',
+    FIXED: 'CTXT',
     FILTER: 'FILTER',
     ADDRESS: 'ADRESSE',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/huHU.ts
+++ b/src/i18n/languages/huHU.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ÉRTÉK!',
   },
   functions: {
+    'RANK.AVG': 'RANG.ÁTL',
+    NUMBERVALUE: 'SZÁM.ÉRTÉK',
     IRR: 'BMR',
     FIXED: 'FIX',
     FILTER: 'FILTER',

--- a/src/i18n/languages/huHU.ts
+++ b/src/i18n/languages/huHU.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ÉRTÉK!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'RANG.ÁTL',
     NUMBERVALUE: 'SZÁM.ÉRTÉK',
     IRR: 'BMR',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'F.PRÓBA',
     STEYX: 'STHIBAYX',
     SLOPE: 'MEREDEKSÉG',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'KOVAR',
     'COVARIANCE.P': 'KOVARIANCIA.S',
     'COVARIANCE.S': 'KOVARIANCIA.M',

--- a/src/i18n/languages/huHU.ts
+++ b/src/i18n/languages/huHU.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ÉRTÉK!',
   },
   functions: {
+    IRR: 'BMR',
+    FIXED: 'FIX',
     FILTER: 'FILTER',
     ADDRESS: 'CÍM',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/itIT.ts
+++ b/src/i18n/languages/itIT.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALORE!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'RANGO.MEDIA',
     NUMBERVALUE: 'NUMERO.VALORE',
     IRR: 'TIR.COST',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'TEST.F',
     STEYX: 'ERR.STD.YX',
     SLOPE: 'PENDENZA',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'COVARIANZA',
     'COVARIANCE.P': 'COVARIANZA.P',
     'COVARIANCE.S': 'COVARIANZA.C',

--- a/src/i18n/languages/itIT.ts
+++ b/src/i18n/languages/itIT.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALORE!',
   },
   functions: {
+    'RANK.AVG': 'RANGO.MEDIA',
+    NUMBERVALUE: 'NUMERO.VALORE',
     IRR: 'TIR.COST',
     FIXED: 'FISSO',
     FILTER: 'FILTER',

--- a/src/i18n/languages/itIT.ts
+++ b/src/i18n/languages/itIT.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALORE!',
   },
   functions: {
+    IRR: 'TIR.COST',
+    FIXED: 'FISSO',
     FILTER: 'FILTER',
     ADDRESS: 'INDIRIZZO',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/nbNO.ts
+++ b/src/i18n/languages/nbNO.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VERDI!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'RANG.GJSN',
     NUMBERVALUE: 'TALLVERDI',
     IRR: 'IR',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'FTEST',
     STEYX: 'STANDARDFEIL',
     SLOPE: 'STIGNINGSTALL',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'KOVARIANS',
     'COVARIANCE.P': 'KOVARIANS.P',
     'COVARIANCE.S': 'KOVARIANS.S',

--- a/src/i18n/languages/nbNO.ts
+++ b/src/i18n/languages/nbNO.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VERDI!',
   },
   functions: {
+    IRR: 'IR',
+    FIXED: 'FIKSER',
     FILTER: 'FILTER',
     ADDRESS: 'ADRESSE',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/nbNO.ts
+++ b/src/i18n/languages/nbNO.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VERDI!',
   },
   functions: {
+    'RANK.AVG': 'RANG.GJSN',
+    NUMBERVALUE: 'TALLVERDI',
     IRR: 'IR',
     FIXED: 'FIKSER',
     FILTER: 'FILTER',

--- a/src/i18n/languages/nlNL.ts
+++ b/src/i18n/languages/nlNL.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#WAARDE!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'RANG.GEMIDDELDE',
     NUMBERVALUE: 'NUMERIEKE.WAARDE',
     IRR: 'IR',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'F.TOETS',
     STEYX: 'STAND.FOUT.YX',
     SLOPE: 'RICHTING',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'COVARIANTIE',
     'COVARIANCE.P': 'COVARIANTIE.P',
     'COVARIANCE.S': 'COVARIANTIE.S',

--- a/src/i18n/languages/nlNL.ts
+++ b/src/i18n/languages/nlNL.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#WAARDE!',
   },
   functions: {
+    IRR: 'IR',
+    FIXED: 'VAST',
     FILTER: 'FILTER',
     ADDRESS: 'ADRES',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/nlNL.ts
+++ b/src/i18n/languages/nlNL.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#WAARDE!',
   },
   functions: {
+    'RANK.AVG': 'RANG.GEMIDDELDE',
+    NUMBERVALUE: 'NUMERIEKE.WAARDE',
     IRR: 'IR',
     FIXED: 'VAST',
     FILTER: 'FILTER',

--- a/src/i18n/languages/plPL.ts
+++ b/src/i18n/languages/plPL.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ARG!',
   },
   functions: {
+    'RANK.AVG': 'ŚREDNIA.POZYCJA',
+    NUMBERVALUE: 'WARTOŚĆ.LICZBOWA',
     IRR: 'IRR',
     FIXED: 'ZAOKR.DO.TEKST',
     FILTER: 'FILTER',

--- a/src/i18n/languages/plPL.ts
+++ b/src/i18n/languages/plPL.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ARG!',
   },
   functions: {
+    IRR: 'IRR',
+    FIXED: 'ZAOKR.DO.TEKST',
     FILTER: 'FILTER',
     ADDRESS: 'ADRES',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/plPL.ts
+++ b/src/i18n/languages/plPL.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ARG!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'ŚREDNIA.POZYCJA',
     NUMBERVALUE: 'WARTOŚĆ.LICZBOWA',
     IRR: 'IRR',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'TEST.F',
     STEYX: 'REGBŁSTD',
     SLOPE: 'NACHYLENIE',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'KOWARIANCJA',
     'COVARIANCE.P': 'KOWARIANCJA.POPUL',
     'COVARIANCE.S': 'KOWARIANCJA.PRÓBKI',

--- a/src/i18n/languages/ptPT.ts
+++ b/src/i18n/languages/ptPT.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALOR!',
   },
   functions: {
+    'RANK.AVG': 'ORDEM.MÉD',
+    NUMBERVALUE: 'VALOR.NÚMERO',
     IRR: 'TIR',
     FIXED: 'FIXA',
     FILTER: 'FILTER',

--- a/src/i18n/languages/ptPT.ts
+++ b/src/i18n/languages/ptPT.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALOR!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'ORDEM.MÉD',
     NUMBERVALUE: 'VALOR.NÚMERO',
     IRR: 'TIR',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'TESTEF',
     STEYX: 'EPADYX',
     SLOPE: 'INCLINAÇÃO',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'COVAR',
     'COVARIANCE.P': 'COVARIAÇÃO.P',
     'COVARIANCE.S': 'COVARIAÇÃO.S',

--- a/src/i18n/languages/ptPT.ts
+++ b/src/i18n/languages/ptPT.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VALOR!',
   },
   functions: {
+    IRR: 'TIR',
+    FIXED: 'FIXA',
     FILTER: 'FILTER',
     ADDRESS: 'ENDEREÇO',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/ruRU.ts
+++ b/src/i18n/languages/ruRU.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ЗНАЧ!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'РАНГ.СР',
     NUMBERVALUE: 'ЧЗНАЧ',
     IRR: 'ВСД',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'ФТЕСТ',
     STEYX: 'СТОШYX',
     SLOPE: 'НАКЛОН',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'КОВАР',
     'COVARIANCE.P': 'КОВАРИАЦИЯ.Г',
     'COVARIANCE.S': 'КОВАРИАЦИЯ.В',

--- a/src/i18n/languages/ruRU.ts
+++ b/src/i18n/languages/ruRU.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ЗНАЧ!',
   },
   functions: {
+    IRR: 'ВСД',
+    FIXED: 'ФИКСИРОВАННЫЙ',
     FILTER: 'FILTER',
     ADDRESS: 'АДРЕС',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/ruRU.ts
+++ b/src/i18n/languages/ruRU.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#ЗНАЧ!',
   },
   functions: {
+    'RANK.AVG': 'РАНГ.СР',
+    NUMBERVALUE: 'ЧЗНАЧ',
     IRR: 'ВСД',
     FIXED: 'ФИКСИРОВАННЫЙ',
     FILTER: 'FILTER',

--- a/src/i18n/languages/svSE.ts
+++ b/src/i18n/languages/svSE.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VÄRDEFEL!',
   },
   functions: {
+    IRR: 'IRR',
+    FIXED: 'FASTTAL',
     FILTER: 'FILTER',
     ADDRESS: 'ADRESS',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/svSE.ts
+++ b/src/i18n/languages/svSE.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VÄRDEFEL!',
   },
   functions: {
+    'RANK.AVG': 'RANG.MED',
+    NUMBERVALUE: 'TALVÄRDE',
     IRR: 'IRR',
     FIXED: 'FASTTAL',
     FILTER: 'FILTER',

--- a/src/i18n/languages/svSE.ts
+++ b/src/i18n/languages/svSE.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#VÄRDEFEL!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'RANG.MED',
     NUMBERVALUE: 'TALVÄRDE',
     IRR: 'IRR',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'FTEST',
     STEYX: 'STDFELYX',
     SLOPE: 'LUTNING',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'KOVAR',
     'COVARIANCE.P': 'KOVARIANS.P',
     'COVARIANCE.S': 'KOVARIANS.S',

--- a/src/i18n/languages/trTR.ts
+++ b/src/i18n/languages/trTR.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#DEĞER!',
   },
   functions: {
+    IRR: 'IRR',
+    FIXED: 'SAYIDÜZENLE',
     FILTER: 'FILTER',
     ADDRESS: 'ADRES',
     'ARRAY_CONSTRAIN': 'ARRAY_CONSTRAIN',

--- a/src/i18n/languages/trTR.ts
+++ b/src/i18n/languages/trTR.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#DEĞER!',
   },
   functions: {
+    HSTACK: 'HSTACK',
+    VSTACK: 'VSTACK',
     'RANK.AVG': 'RANK.ORT',
     NUMBERVALUE: 'SAYIDEĞERI',
     IRR: 'IRR',
@@ -391,6 +393,7 @@ const dictionary: RawTranslationPackage = {
     FTEST: 'FTEST',
     STEYX: 'STHYX',
     SLOPE: 'EĞİM',
+    INTERCEPT: 'INTERCEPT',
     COVAR: 'KOVARYANS',
     'COVARIANCE.P': 'KOVARYANS.P',
     'COVARIANCE.S': 'KOVARYANS.S',

--- a/src/i18n/languages/trTR.ts
+++ b/src/i18n/languages/trTR.ts
@@ -18,6 +18,8 @@ const dictionary: RawTranslationPackage = {
     VALUE: '#DEĞER!',
   },
   functions: {
+    'RANK.AVG': 'RANK.ORT',
+    NUMBERVALUE: 'SAYIDEĞERI',
     IRR: 'IRR',
     FIXED: 'SAYIDÜZENLE',
     FILTER: 'FILTER',

--- a/src/interpreter/ArithmeticHelper.ts
+++ b/src/interpreter/ArithmeticHelper.ts
@@ -124,7 +124,7 @@ export class ArithmeticHelper {
   }
 
   public pow = (left: ExtendedNumber, right: ExtendedNumber) => {
-    return realPow(getRawValue(left), getRawValue(right))
+    return Math.pow(getRawValue(left), getRawValue(right))
   }
 
   public addWithEpsilonRaw = (left: number, right: number): number => {
@@ -567,22 +567,6 @@ export class ArithmeticHelper {
       return [0, val]
     }
   }
-}
-
-/**
- * Raise `base` to `exp`, matching Excel's `^`/POWER for a negative base. `Math.pow(negative, fractional)`
- * is NaN, but Excel returns the real root when the exponent is the reciprocal of an ODD integer (cube,
- * 5th, 7th root…) — e.g. `(-8)^(1/3) = -2`. Even roots of a negative base stay NaN (Excel returns #NUM!).
- */
-export function realPow(base: number, exp: number): number {
-  if (base < 0 && Number.isFinite(exp) && !Number.isInteger(exp)) {
-    const reciprocal = 1 / exp
-    const rounded = Math.round(reciprocal)
-    if (rounded !== 0 && rounded % 2 !== 0 && Math.abs(reciprocal - rounded) < 1e-10) {
-      return -Math.pow(-base, exp)
-    }
-  }
-  return Math.pow(base, exp)
 }
 
 export function coerceComplexToString([re, im]: complex, symb?: string): string | CellError {

--- a/src/interpreter/ArithmeticHelper.ts
+++ b/src/interpreter/ArithmeticHelper.ts
@@ -124,7 +124,7 @@ export class ArithmeticHelper {
   }
 
   public pow = (left: ExtendedNumber, right: ExtendedNumber) => {
-    return Math.pow(getRawValue(left), getRawValue(right))
+    return realPow(getRawValue(left), getRawValue(right))
   }
 
   public addWithEpsilonRaw = (left: number, right: number): number => {
@@ -567,6 +567,22 @@ export class ArithmeticHelper {
       return [0, val]
     }
   }
+}
+
+/**
+ * Raise `base` to `exp`, matching Excel's `^`/POWER for a negative base. `Math.pow(negative, fractional)`
+ * is NaN, but Excel returns the real root when the exponent is the reciprocal of an ODD integer (cube,
+ * 5th, 7th root…) — e.g. `(-8)^(1/3) = -2`. Even roots of a negative base stay NaN (Excel returns #NUM!).
+ */
+export function realPow(base: number, exp: number): number {
+  if (base < 0 && Number.isFinite(exp) && !Number.isInteger(exp)) {
+    const reciprocal = 1 / exp
+    const rounded = Math.round(reciprocal)
+    if (rounded !== 0 && rounded % 2 !== 0 && Math.abs(reciprocal - rounded) < 1e-10) {
+      return -Math.pow(-base, exp)
+    }
+  }
+  return Math.pow(base, exp)
 }
 
 export function coerceComplexToString([re, im]: complex, symb?: string): string | CellError {

--- a/src/interpreter/plugin/ArrayPlugin.ts
+++ b/src/interpreter/plugin/ArrayPlugin.ts
@@ -42,6 +42,24 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
         {argumentType: FunctionArgumentType.RANGE},
       ],
       repeatLastArgs: 1,
+    },
+    'VSTACK': {
+      method: 'vstack',
+      arraySizeMethod: 'vstackArraySize',
+      arrayFunction: true,
+      parameters: [
+        {argumentType: FunctionArgumentType.RANGE},
+      ],
+      repeatLastArgs: 1,
+    },
+    'HSTACK': {
+      method: 'hstack',
+      arraySizeMethod: 'hstackArraySize',
+      arrayFunction: true,
+      parameters: [
+        {argumentType: FunctionArgumentType.RANGE},
+      ],
+      repeatLastArgs: 1,
     }
   }
 
@@ -145,6 +163,62 @@ export class ArrayPlugin extends FunctionPlugin implements FunctionPluginTypeche
 
     const width = Math.max(...(subChecks).map(val => val.width))
     const height = Math.max(...(subChecks).map(val => val.height))
+    return new ArraySize(width, height)
+  }
+
+  public vstack(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('VSTACK'), (...ranges: SimpleRangeValue[]) => {
+      const width = Math.max(...ranges.map(range => range.width()))
+      const result: InternalScalarValue[][] = []
+      for (const range of ranges) {
+        for (const row of range.data) {
+          const padded = row.slice()
+          while (padded.length < width) {
+            padded.push(new CellError(ErrorType.NA))
+          }
+          result.push(padded)
+        }
+      }
+      return SimpleRangeValue.onlyValues(result)
+    })
+  }
+
+  public vstackArraySize(ast: ProcedureAst, state: InterpreterState): ArraySize {
+    if (ast.args.length === 0) {
+      return ArraySize.error()
+    }
+    const metadata = this.metadata('VSTACK')
+    const subChecks = ast.args.map((arg) => this.arraySizeForAst(arg, new InterpreterState(state.formulaAddress, state.arraysFlag || (metadata?.arrayFunction ?? false))))
+    const width = Math.max(...subChecks.map(val => val.width))
+    const height = subChecks.reduce((sum, val) => sum + val.height, 0)
+    return new ArraySize(width, height)
+  }
+
+  public hstack(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('HSTACK'), (...ranges: SimpleRangeValue[]) => {
+      const height = Math.max(...ranges.map(range => range.height()))
+      const result: InternalScalarValue[][] = Array.from({length: height}, () => [])
+      for (const range of ranges) {
+        const data = range.data
+        for (let i = 0; i < height; i++) {
+          const sourceRow: InternalScalarValue[] | undefined = data[i]
+          for (let j = 0; j < range.width(); j++) {
+            result[i].push(sourceRow ? sourceRow[j] : new CellError(ErrorType.NA))
+          }
+        }
+      }
+      return SimpleRangeValue.onlyValues(result)
+    })
+  }
+
+  public hstackArraySize(ast: ProcedureAst, state: InterpreterState): ArraySize {
+    if (ast.args.length === 0) {
+      return ArraySize.error()
+    }
+    const metadata = this.metadata('HSTACK')
+    const subChecks = ast.args.map((arg) => this.arraySizeForAst(arg, new InterpreterState(state.formulaAddress, state.arraysFlag || (metadata?.arrayFunction ?? false))))
+    const width = subChecks.reduce((sum, val) => sum + val.width, 0)
+    const height = Math.max(...subChecks.map(val => val.height))
     return new ArraySize(width, height)
   }
 }

--- a/src/interpreter/plugin/FinancialPlugin.ts
+++ b/src/interpreter/plugin/FinancialPlugin.ts
@@ -256,6 +256,14 @@ export class FinancialPlugin extends FunctionPlugin implements FunctionPluginTyp
       repeatLastArgs: 1,
       returnNumberType: NumberType.NUMBER_CURRENCY
     },
+    'IRR': {
+      method: 'irr',
+      parameters: [
+        {argumentType: FunctionArgumentType.RANGE},
+        {argumentType: FunctionArgumentType.NUMBER, defaultValue: 0.1},
+      ],
+      returnNumberType: NumberType.NUMBER_PERCENT
+    },
     'MIRR': {
       method: 'mirr',
       parameters: [
@@ -663,6 +671,20 @@ export class FinancialPlugin extends FunctionPlugin implements FunctionPluginTyp
     )
   }
 
+  public irr(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('IRR'),
+      (range: SimpleRangeValue, guess: number) => {
+        // Excel IRR reads cash flows in range order, ignoring text/logical/empty cells and
+        // propagating a cell error — exactly manyToExactNumbers' behaviour (as used by MIRR).
+        const cashflows = this.arithmeticHelper.manyToExactNumbers(range.valuesFromTopLeftCorner())
+        if (cashflows instanceof CellError) {
+          return cashflows
+        }
+        return irrCore(cashflows, guess)
+      }
+    )
+  }
+
   public mirr(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('MIRR'),
       (range: SimpleRangeValue, frate: number, rrate: number) => {
@@ -781,6 +803,58 @@ function fvCore(rate: number, periods: number, payment: number, value: number, t
 
 function ppmtCore(rate: number, period: number, periods: number, present: number, future: number, type: number): number {
   return pmtCore(rate, periods, present, future, type) - ipmtCore(rate, period, periods, present, future, type)
+}
+
+function irrNpv(cashflows: number[], rate: number): number {
+  let acc = 0
+  for (let i = 0; i < cashflows.length; i++) {
+    acc += cashflows[i] / Math.pow(1 + rate, i)
+  }
+  return acc
+}
+
+/*
+ * IRR is the discount rate r for which the cash flows sum to zero: sum_i cf_i / (1+r)^i = 0, with the
+ * first flow at period 0 (undiscounted). Solved with Newton-Raphson from `guess`; on divergence or a flat
+ * derivative we return #NUM! (Excel's behaviour), and a step below -1 is damped back toward -1 to stay in
+ * the function's domain. A root only exists when the flows change sign, so same-sign input short-circuits.
+ * A converged step is accepted only when the rate is in-domain (1+r > 0) AND the NPV residual is actually
+ * ~0 — Newton can "converge" (tiny step) on a flat tail to a value that is not a root, and Excel returns
+ * #NUM! for those; the residual is compared relative to the cash-flow magnitude so scale doesn't matter.
+ */
+function irrCore(cashflows: number[], guess: number): number | CellError {
+  if (cashflows.length < 2 || !cashflows.some(v => v > 0) || !cashflows.some(v => v < 0)) {
+    return new CellError(ErrorType.NUM, ErrorMessage.NoConvergence)
+  }
+  const magnitude = cashflows.reduce((acc, v) => acc + Math.abs(v), 0)
+  const maxIterations = 50
+  const stepTolerance = 1e-10
+  const residualTolerance = 1e-7 * (magnitude || 1)
+  let rate = guess > -1 ? guess : -0.999999
+  for (let iteration = 0; iteration < maxIterations; iteration++) {
+    let npv = 0
+    let derivative = 0
+    for (let i = 0; i < cashflows.length; i++) {
+      const denominator = Math.pow(1 + rate, i)
+      npv += cashflows[i] / denominator
+      derivative -= (i * cashflows[i]) / (denominator * (1 + rate))
+    }
+    if (!isFinite(npv) || !isFinite(derivative) || derivative === 0) {
+      break
+    }
+    const nextRate = rate - npv / derivative
+    if (!isFinite(nextRate)) {
+      break
+    }
+    if (Math.abs(nextRate - rate) < stepTolerance) {
+      if (nextRate > -1 && Math.abs(irrNpv(cashflows, nextRate)) <= residualTolerance) {
+        return nextRate
+      }
+      break
+    }
+    rate = nextRate <= -1 ? (rate - 1) / 2 : nextRate
+  }
+  return new CellError(ErrorType.NUM, ErrorMessage.NoConvergence)
 }
 
 function npvCore(rate: number, args: number[]): number | CellError {

--- a/src/interpreter/plugin/FinancialPlugin.ts
+++ b/src/interpreter/plugin/FinancialPlugin.ts
@@ -739,15 +739,26 @@ export class FinancialPlugin extends FunctionPlugin implements FunctionPluginTyp
   public xnpv(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('XNPV'),
       (rate: number, values: SimpleRangeValue, dates: SimpleRangeValue) => {
-        const valArr = values.valuesFromTopLeftCorner()
+        // Unwrap ExtendedNumber (formatted/date/percent cells wrap their number as { val, format }) before
+        // the numeric check — a real model's dates row is date-formatted, so a raw typeof test wrongly
+        // rejects it as #VALUE!. getRawValue leaves primitives untouched.
+        const valArr = values.valuesFromTopLeftCorner().map(getRawValue)
         for (const val of valArr) {
+          // Propagate a real input error (e.g. #REF! from a deleted cell) with its own type, matching
+          // Excel; only a genuinely non-numeric, non-error value is a #VALUE!/NumberExpected.
+          if (val instanceof CellError) {
+            return val
+          }
           if (typeof val !== 'number') {
             return new CellError(ErrorType.VALUE, ErrorMessage.NumberExpected)
           }
         }
         const valArrNum = valArr as number[]
-        const dateArr = dates.valuesFromTopLeftCorner()
+        const dateArr = dates.valuesFromTopLeftCorner().map(getRawValue)
         for (const date of dateArr) {
+          if (date instanceof CellError) {
+            return date
+          }
           if (typeof date !== 'number') {
             return new CellError(ErrorType.VALUE, ErrorMessage.NumberExpected)
           }

--- a/src/interpreter/plugin/LookupPlugin.ts
+++ b/src/interpreter/plugin/LookupPlugin.ts
@@ -336,14 +336,24 @@ export class LookupPlugin extends FunctionPlugin implements FunctionPluginTypech
     }
 
     const searchStrategy = rangeValue.width() === 1 ? this.columnSearch : this.rowSearch
-    const searchOptions: SearchOptions = type === 0
-      ? { ordering: 'none', ifNoMatch: 'returnNotFound' }
-      : { ordering: type === -1 ? 'desc' : 'asc', ifNoMatch: type === -1 ? 'returnUpperBound' : 'returnLowerBound' }
-    const index = searchStrategy.find(key, rangeValue, searchOptions)
-
-    if (index === -1) {
-      return new CellError(ErrorType.NA, ErrorMessage.ValueNotFound)
+    if (type === 0) {
+      const index = searchStrategy.find(key, rangeValue, { ifNoMatch: 'returnNotFound', ordering: 'none' })
+      return index === -1 ? new CellError(ErrorType.NA, ErrorMessage.ValueNotFound) : index + 1
     }
-    return index + 1
+
+    const orderedOptions: SearchOptions =
+      type === -1
+        ? { ifNoMatch: 'returnUpperBound', ordering: 'desc' }
+        : { ifNoMatch: 'returnLowerBound', ordering: 'asc' }
+    const index = searchStrategy.find(key, rangeValue, orderedOptions)
+    if (index !== -1) {
+      return index + 1
+    }
+
+    // Approximate match (type 1/-1) binary-searches assuming the range is sorted. When it isn't, the
+    // search can miss a value that is actually present; Excel still returns it. Fall back to an exact
+    // scan so a present exact value isn't lost to the sort assumption.
+    const exactIndex = searchStrategy.find(key, rangeValue, { ifNoMatch: 'returnNotFound', ordering: 'none' })
+    return exactIndex === -1 ? new CellError(ErrorType.NA, ErrorMessage.ValueNotFound) : exactIndex + 1
   }
 }

--- a/src/interpreter/plugin/MedianPlugin.ts
+++ b/src/interpreter/plugin/MedianPlugin.ts
@@ -38,6 +38,14 @@ export class MedianPlugin extends FunctionPlugin implements FunctionPluginTypech
         {argumentType: FunctionArgumentType.NUMBER, minValue: 1},
       ],
     },
+    'RANK.AVG': {
+      method: 'rankAvg',
+      parameters: [
+        {argumentType: FunctionArgumentType.NUMBER},
+        {argumentType: FunctionArgumentType.RANGE},
+        {argumentType: FunctionArgumentType.NUMBER, defaultValue: 0},
+      ],
+    },
   }
 
   /**
@@ -65,6 +73,25 @@ export class MedianPlugin extends FunctionPlugin implements FunctionPluginTypech
           return values[Math.floor(values.length / 2)]
         }
       })
+  }
+
+  public rankAvg(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('RANK.AVG'),
+      (value: number, range: SimpleRangeValue, order: number) => {
+        const vals = this.arithmeticHelper.manyToExactNumbers(range.valuesFromTopLeftCorner())
+        if (vals instanceof CellError) {
+          return vals
+        }
+        const ties = vals.filter(v => v === value).length
+        if (ties === 0) {
+          return new CellError(ErrorType.NA, ErrorMessage.ValueNotFound)
+        }
+        // order 0 (or omitted) = descending: rank 1 is the largest. Non-zero = ascending. Tied values
+        // share the average of the consecutive ranks they occupy.
+        const better = order === 0 ? vals.filter(v => v > value).length : vals.filter(v => v < value).length
+        return better + (ties + 1) / 2
+      }
+    )
   }
 
   public large(ast: ProcedureAst, state: InterpreterState): InterpreterValue {

--- a/src/interpreter/plugin/PowerPlugin.ts
+++ b/src/interpreter/plugin/PowerPlugin.ts
@@ -4,7 +4,6 @@
  */
 
 import {ProcedureAst} from '../../parser'
-import {realPow} from '../ArithmeticHelper'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
 import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
@@ -21,6 +20,6 @@ export class PowerPlugin extends FunctionPlugin implements FunctionPluginTypeche
   }
 
   public power(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
-    return this.runFunction(ast.args, state, this.metadata('POWER'), realPow)
+    return this.runFunction(ast.args, state, this.metadata('POWER'), Math.pow)
   }
 }

--- a/src/interpreter/plugin/PowerPlugin.ts
+++ b/src/interpreter/plugin/PowerPlugin.ts
@@ -4,6 +4,7 @@
  */
 
 import {ProcedureAst} from '../../parser'
+import {realPow} from '../ArithmeticHelper'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue} from '../InterpreterValue'
 import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
@@ -20,6 +21,6 @@ export class PowerPlugin extends FunctionPlugin implements FunctionPluginTypeche
   }
 
   public power(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
-    return this.runFunction(ast.args, state, this.metadata('POWER'), Math.pow)
+    return this.runFunction(ast.args, state, this.metadata('POWER'), realPow)
   }
 }

--- a/src/interpreter/plugin/StatisticalAggregationPlugin.ts
+++ b/src/interpreter/plugin/StatisticalAggregationPlugin.ts
@@ -117,6 +117,13 @@ export class StatisticalAggregationPlugin extends FunctionPlugin implements Func
         {argumentType: FunctionArgumentType.RANGE},
       ],
     },
+    'INTERCEPT': {
+      method: 'intercept',
+      parameters: [
+        {argumentType: FunctionArgumentType.RANGE},
+        {argumentType: FunctionArgumentType.RANGE},
+      ],
+    },
     'CHISQ.TEST': {
       method: 'chisqtest',
       parameters: [
@@ -390,6 +397,27 @@ export class StatisticalAggregationPlugin extends FunctionPlugin implements Func
           return new CellError(ErrorType.DIV_BY_ZERO, ErrorMessage.TwoValues)
         }
         return covariance(ret[0], ret[1]) * (n - 1) / sumsqerr(ret[1])
+      })
+  }
+
+  public intercept(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('INTERCEPT'),
+      (knownYs: SimpleRangeValue, knownXs: SimpleRangeValue) => {
+        if (knownYs.numberOfElements() !== knownXs.numberOfElements()) {
+          return new CellError(ErrorType.NA, ErrorMessage.EqualLength)
+        }
+
+        const ret = parseTwoArrays(knownYs, knownXs)
+        if (ret instanceof CellError) {
+          return ret
+        }
+        const n = ret[0].length
+        if (n <= 1) {
+          return new CellError(ErrorType.DIV_BY_ZERO, ErrorMessage.TwoValues)
+        }
+        // intercept = mean(y) - slope * mean(x), slope = cov(y,x)*(n-1) / sumsqerr(x)
+        const slope = covariance(ret[0], ret[1]) * (n - 1) / sumsqerr(ret[1])
+        return mean(ret[0]) - slope * mean(ret[1])
       })
   }
 

--- a/src/interpreter/plugin/StatisticalAggregationPlugin.ts
+++ b/src/interpreter/plugin/StatisticalAggregationPlugin.ts
@@ -377,6 +377,9 @@ export class StatisticalAggregationPlugin extends FunctionPlugin implements Func
         if (n <= 2) {
           return new CellError(ErrorType.DIV_BY_ZERO, ErrorMessage.ThreeValues)
         }
+        if (sumsqerr(ret[1]) === 0) {
+          return new CellError(ErrorType.DIV_BY_ZERO)
+        }
         return Math.sqrt((sumsqerr(ret[0]) - Math.pow(covariance(ret[0], ret[1]) * (n - 1), 2) / sumsqerr(ret[1])) / (n - 2))
       })
   }
@@ -395,6 +398,9 @@ export class StatisticalAggregationPlugin extends FunctionPlugin implements Func
         const n = ret[0].length
         if (n <= 1) {
           return new CellError(ErrorType.DIV_BY_ZERO, ErrorMessage.TwoValues)
+        }
+        if (sumsqerr(ret[1]) === 0) {
+          return new CellError(ErrorType.DIV_BY_ZERO)
         }
         return covariance(ret[0], ret[1]) * (n - 1) / sumsqerr(ret[1])
       })
@@ -415,8 +421,12 @@ export class StatisticalAggregationPlugin extends FunctionPlugin implements Func
         if (n <= 1) {
           return new CellError(ErrorType.DIV_BY_ZERO, ErrorMessage.TwoValues)
         }
-        // intercept = mean(y) - slope * mean(x), slope = cov(y,x)*(n-1) / sumsqerr(x)
-        const slope = covariance(ret[0], ret[1]) * (n - 1) / sumsqerr(ret[1])
+        // intercept = mean(y) - slope * mean(x), slope = cov(y,x)*(n-1) / sumsqerr(x). Zero x-variance
+        // (all known_x identical) makes slope undefined — Excel returns #DIV/0! rather than a non-finite number.
+        if (sumsqerr(ret[1]) === 0) {
+          return new CellError(ErrorType.DIV_BY_ZERO)
+        }
+        const slope = (covariance(ret[0], ret[1]) * (n - 1)) / sumsqerr(ret[1])
         return mean(ret[0]) - slope * mean(ret[1])
       })
   }

--- a/src/interpreter/plugin/TextPlugin.ts
+++ b/src/interpreter/plugin/TextPlugin.ts
@@ -5,6 +5,7 @@
 
 import {CellError, ErrorType} from '../../Cell'
 import {ErrorMessage} from '../../error-message'
+import {roundHalfAwayFromZero} from '../../format/format'
 import {ProcedureAst} from '../../parser'
 import {InterpreterState} from '../InterpreterState'
 import {InterpreterValue, RawScalarValue} from '../InterpreterValue'
@@ -22,6 +23,14 @@ export class TextPlugin extends FunctionPlugin implements FunctionPluginTypechec
       ],
       repeatLastArgs: 1,
       expandRanges: true,
+    },
+    'FIXED': {
+      method: 'fixed',
+      parameters: [
+        {argumentType: FunctionArgumentType.NUMBER},
+        {argumentType: FunctionArgumentType.NUMBER, defaultValue: 2},
+        {argumentType: FunctionArgumentType.BOOLEAN, defaultValue: false},
+      ],
     },
     'CONCAT': {
       method: 'concat',
@@ -179,6 +188,49 @@ export class TextPlugin extends FunctionPlugin implements FunctionPluginTypechec
   public concatenate(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('CONCATENATE'), (...args) => {
       return ''.concat(...args)
+    })
+  }
+
+  public fixed(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('FIXED'), (value: number, decimals: number, noCommas: boolean) => {
+      const places = Math.trunc(decimals)
+      // Reuse the format engine's decimal-string rounder (round-half-away-from-zero without the
+      // multiply-based IEEE noise, e.g. 1.005 -> "1.01"). It leaves extreme magnitudes/precisions
+      // unshifted; that's fine here, the double already carries every significant digit.
+      let rounded = roundHalfAwayFromZero(value, places)
+      if (Number.isNaN(rounded)) {
+        rounded = value
+      }
+      if (!isFinite(rounded)) {
+        return new CellError(ErrorType.VALUE, ErrorMessage.NaN)
+      }
+      // toFixed only accepts 0..100 fraction digits and switches to exponent form at 1e21; guard both
+      // so a large `decimals` or magnitude can never throw or leak an "e" into the grouped output.
+      const decimalPlaces = Math.min(100, Math.max(0, places))
+      const magnitude = Math.abs(rounded)
+      const body = magnitude < 1e21
+        ? magnitude.toFixed(decimalPlaces)
+        : magnitude.toLocaleString('en-US', {maximumFractionDigits: 0, useGrouping: false}) +
+          (decimalPlaces > 0 ? `.${'0'.repeat(decimalPlaces)}` : '')
+
+      const [integerPart, decimalPart] = body.split('.')
+      const decimalSeparator = this.config.decimalSeparator
+      // Never let the grouping separator collide with the decimal separator (a comma-decimal locale
+      // groups with '.'), and honour an explicit config separator when set.
+      const thousandSeparator = noCommas
+        ? ''
+        : this.config.thousandSeparator !== ''
+          ? this.config.thousandSeparator
+          : decimalSeparator === ','
+            ? '.'
+            : ','
+      const groupedInteger = thousandSeparator === ''
+        ? integerPart
+        : integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator)
+      const magnitudeText = decimalPart === undefined ? groupedInteger : `${groupedInteger}${decimalSeparator}${decimalPart}`
+      // A value that rounds to zero yields +0/-0, for which `rounded < 0` is already false, so no
+      // sign leaks onto "0.00" (Excel: FIXED(-0.001,1) -> "0.0").
+      return rounded < 0 ? `-${magnitudeText}` : magnitudeText
     })
   }
 

--- a/src/interpreter/plugin/TextPlugin.ts
+++ b/src/interpreter/plugin/TextPlugin.ts
@@ -210,7 +210,7 @@ export class TextPlugin extends FunctionPlugin implements FunctionPluginTypechec
         rounded = value
       }
       if (!isFinite(rounded)) {
-        return new CellError(ErrorType.VALUE, ErrorMessage.NaN)
+        return new CellError(ErrorType.NUM, ErrorMessage.NaN)
       }
       // toFixed only accepts 0..100 fraction digits and switches to exponent form at 1e21; guard both
       // so a large `decimals` or magnitude can never throw or leak an "e" into the grouped output.

--- a/src/interpreter/plugin/TextPlugin.ts
+++ b/src/interpreter/plugin/TextPlugin.ts
@@ -175,6 +175,14 @@ export class TextPlugin extends FunctionPlugin implements FunctionPluginTypechec
         {argumentType: FunctionArgumentType.NUMBER}
       ]
     },
+    'NUMBERVALUE': {
+      method: 'numberValue',
+      parameters: [
+        {argumentType: FunctionArgumentType.STRING},
+        {argumentType: FunctionArgumentType.STRING, optionalArg: true},
+        {argumentType: FunctionArgumentType.STRING, optionalArg: true},
+      ]
+    },
   }
 
   /**
@@ -449,6 +457,46 @@ export class TextPlugin extends FunctionPlugin implements FunctionPluginTypechec
    */
   public value(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
     return this.runFunction(ast.args, state, this.metadata('VALUE'), (value: number) => value)
+  }
+
+  public numberValue(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(
+      ast.args,
+      state,
+      this.metadata('NUMBERVALUE'),
+      (text: string, decimalSeparatorArg?: string, groupSeparatorArg?: string) => {
+        const decimalSeparator = (decimalSeparatorArg ?? this.config.decimalSeparator).charAt(0) || '.'
+        const groupSeparator = (groupSeparatorArg ?? this.config.thousandSeparator).charAt(0)
+        if (groupSeparator !== '' && groupSeparator === decimalSeparator) {
+          return new CellError(ErrorType.VALUE, ErrorMessage.NumberCoercion)
+        }
+        // Excel NUMBERVALUE ignores all whitespace, strips group separators, normalises the decimal
+        // separator to '.', and divides by 100 for each trailing '%'. An empty string is 0.
+        let normalized = text.replace(/\s+/g, '')
+        if (normalized === '') {
+          return 0
+        }
+        let percentDivisor = 1
+        while (normalized.endsWith('%')) {
+          percentDivisor *= 100
+          normalized = normalized.slice(0, -1)
+        }
+        if (groupSeparator !== '') {
+          normalized = normalized.split(groupSeparator).join('')
+        }
+        if (decimalSeparator !== '.') {
+          if (normalized.includes('.')) {
+            return new CellError(ErrorType.VALUE, ErrorMessage.NumberCoercion)
+          }
+          normalized = normalized.split(decimalSeparator).join('.')
+        }
+        // At most one decimal point, then a plain (optionally signed/exponent) number.
+        if ((normalized.match(/\./g) ?? []).length > 1 || !/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(normalized)) {
+          return new CellError(ErrorType.VALUE, ErrorMessage.NumberCoercion)
+        }
+        return Number(normalized) / percentDivisor
+      },
+    )
   }
 
   private escapeRegExpSpecialCharacters(text: string): string {

--- a/test/date.spec.ts
+++ b/test/date.spec.ts
@@ -162,6 +162,13 @@ describe('Date helpers', () => {
     expect(dateHelper11.dateStringToDateNumber('31/99/12')).toEqual(new DateNumber(36525, 'DD/YY/MM'))
   })
 
+  it('stringToDateNumber - month/year format with no day component defaults the day to 1 (Excel MM/YYYY)', () => {
+    const dateHelper = new DateTimeHelper(new Config({dateFormats: ['MM/YYYY']}))
+    // Excel parses "02/2014" as 1 Feb 2014 (serial 41671); "12/1999" -> 1 Dec 1999 (serial 36495)
+    expect(dateHelper.dateStringToDateNumber('02/2014')).toEqual(new DateNumber(41671, 'MM/YYYY'))
+    expect(dateHelper.dateStringToDateNumber('12/1999')).toEqual(new DateNumber(36495, 'MM/YYYY'))
+  })
+
   it('stringToDateNumber - other time formats', () => {
     const dateHelper = new DateTimeHelper(new Config({timeFormats: ['mm:hh']}))
     expect(dateHelper.dateStringToDateNumber('60:02')).toEqual(new TimeNumber(0.125, 'mm:hh'))
@@ -240,10 +247,10 @@ describe('By default function parseDateTimeFromConfigFormats', () => {
     expect(parsedDate).toEqual({})
   })
 
-  it('returns {} when time format contains no day term', () => {
+  it('defaults the day to 1 when the date format has no day term (Excel month/year parsing)', () => {
     const dateHelper = new DateTimeHelper(new Config({ dateFormats: ['MM/YY'] }))
-    const parsedDate = dateHelper.parseDateTimeFromConfigFormats('12/12')
-    expect(parsedDate).toEqual({})
+    const { dateTime } = dateHelper.parseDateTimeFromConfigFormats('12/12')
+    expect(dateTime).toEqual({ year: 2012, month: 12, day: 1 })
   })
 
   it('returns {} when time format contains no month term', () => {

--- a/test/interpreter/function-fixed.spec.ts
+++ b/test/interpreter/function-fixed.spec.ts
@@ -1,0 +1,70 @@
+import {ErrorType, HyperFormula} from '../../src'
+import {ErrorMessage} from '../../src/error-message'
+import {adr, detailedError} from '../testUtils'
+
+describe('Function FIXED', () => {
+  it('should return #NA! with the wrong number of arguments', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED()']])
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NA, ErrorMessage.WrongArgNumber))
+  })
+
+  it('defaults to 2 decimals and groups thousands', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(1234.567)']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('1,234.57')
+  })
+
+  it('rounds to the requested number of decimals', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(1234.567,1)']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('1,234.6')
+  })
+
+  it('rounds left of the decimal point for negative decimals', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(1234.567,-2)']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('1,200')
+  })
+
+  it('omits the thousands separator when no_commas is TRUE', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(1234.567,1,TRUE())']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('1234.6')
+  })
+
+  it('handles negative numbers', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(-1234.567,1)']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('-1,234.6')
+  })
+
+  it('formats a small value with no integer grouping (the BDN percent case)', () => {
+    const engine = HyperFormula.buildFromArray([['="rate of "&FIXED(10.9,1)&"%"']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('rate of 10.9%')
+  })
+
+  it('coerces a numeric string argument', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED("1234.5",0)']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('1,235')
+  })
+
+  it('returns #VALUE! for a non-numeric argument', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED("abc",1)']])
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.NumberCoercion))
+  })
+
+  it('zero decimals rounds to an integer', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(1234.567,0)']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('1,235')
+  })
+
+  it('rounds half away from zero at an IEEE half-boundary (1.005 -> 1.01)', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(1.005,2)']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('1.01')
+  })
+
+  it('does not throw for decimals > 100 (toFixed range guard)', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(1.5,150)']])
+    expect(typeof engine.getCellValue(adr('A1'))).toBe('string')
+  })
+
+  it('expands a magnitude >= 1e21 without exponent notation', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(10^21,0)']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('1,000,000,000,000,000,000,000')
+  })
+})

--- a/test/interpreter/function-fixed.spec.ts
+++ b/test/interpreter/function-fixed.spec.ts
@@ -67,4 +67,9 @@ describe('Function FIXED', () => {
     const engine = HyperFormula.buildFromArray([['=FIXED(10^21,0)']])
     expect(engine.getCellValue(adr('A1'))).toEqual('1,000,000,000,000,000,000,000')
   })
+
+  it('returns #NUM! (not #VALUE!) for a non-finite value', () => {
+    const engine = HyperFormula.buildFromArray([['=FIXED(10^309,0)']])
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NUM))
+  })
 })

--- a/test/interpreter/function-intercept.spec.ts
+++ b/test/interpreter/function-intercept.spec.ts
@@ -53,4 +53,15 @@ describe('INTERCEPT', () => {
 
     expect(engine.getCellValue(adr('A3'))).toEqualError(detailedError(ErrorType.DIV_BY_ZERO, ErrorMessage.TwoValues))
   })
+
+  it('returns #DIV/0! when all known_x values are identical (zero x-variance)', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, 3],
+      [2, 3],
+      [4, 3],
+      ['=INTERCEPT(A1:A3, B1:B3)'],
+    ])
+
+    expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.DIV_BY_ZERO))
+  })
 })

--- a/test/interpreter/function-intercept.spec.ts
+++ b/test/interpreter/function-intercept.spec.ts
@@ -1,0 +1,56 @@
+import {HyperFormula} from '../../src'
+import {ErrorType} from '../../src/Cell'
+import {ErrorMessage} from '../../src/error-message'
+import {adr, detailedError} from '../testUtils'
+
+describe('INTERCEPT', () => {
+  it('validates number of arguments', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['=INTERCEPT(B1:B5)'],
+      ['=INTERCEPT(B1:B5, C1:C5, D1:D5)'],
+    ])
+
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NA, ErrorMessage.WrongArgNumber))
+    expect(engine.getCellValue(adr('A2'))).toEqualError(detailedError(ErrorType.NA, ErrorMessage.WrongArgNumber))
+  })
+
+  it('ranges need to have the same number of elements', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['=INTERCEPT(B1:B5, C1:C6)'],
+    ])
+
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NA, ErrorMessage.EqualLength))
+  })
+
+  it('computes the regression y-intercept', () => {
+    // y = 2x + 1 exactly -> intercept 1
+    const engine = HyperFormula.buildFromArray([
+      [3, 5, 7, 9], // known_y's  (=2x+1 for x=1,2,3,4)
+      [1, 2, 3, 4], // known_x's
+      ['=INTERCEPT(A1:D1, A2:D2)'],
+    ])
+
+    expect(engine.getCellValue(adr('A3'))).toBeCloseTo(1, 9)
+  })
+
+  it('matches Excel on a non-trivial series', () => {
+    // known_y's {2,3,9,1,8}, known_x's {6,5,11,7,5}; slope=16.6/24.8, intercept=4.6-slope*6.8
+    const engine = HyperFormula.buildFromArray([
+      [2, 3, 9, 1, 8],
+      [6, 5, 11, 7, 5],
+      ['=INTERCEPT(A1:E1, A2:E2)'],
+    ])
+
+    expect(engine.getCellValue(adr('A3'))).toBeCloseTo(0.048387, 5)
+  })
+
+  it('needs at least two points', () => {
+    const engine = HyperFormula.buildFromArray([
+      [5],
+      [2],
+      ['=INTERCEPT(A1:A1, A2:A2)'],
+    ])
+
+    expect(engine.getCellValue(adr('A3'))).toEqualError(detailedError(ErrorType.DIV_BY_ZERO, ErrorMessage.TwoValues))
+  })
+})

--- a/test/interpreter/function-irr.spec.ts
+++ b/test/interpreter/function-irr.spec.ts
@@ -1,0 +1,51 @@
+import {ErrorType, HyperFormula} from '../../src'
+import {ErrorMessage} from '../../src/error-message'
+import {adr, detailedError} from '../testUtils'
+
+describe('Function IRR', () => {
+  it('should return #NA! with the wrong number of arguments', () => {
+    const engine = HyperFormula.buildFromArray([['=IRR()']])
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NA, ErrorMessage.WrongArgNumber))
+  })
+
+  it("computes the internal rate of return (Microsoft's documented example)", () => {
+    const engine = HyperFormula.buildFromArray([
+      [-70000], [12000], [15000], [18000], [21000], [26000], ['=IRR(A1:A6)'],
+    ])
+    expect(engine.getCellValue(adr('A7')) as number).toBeCloseTo(0.086631, 5)
+  })
+
+  it('converges from an explicit guess to the same rate', () => {
+    const engine = HyperFormula.buildFromArray([
+      [-70000], [12000], [15000], [18000], [21000], [26000], ['=IRR(A1:A6,-0.1)'],
+    ])
+    expect(engine.getCellValue(adr('A7')) as number).toBeCloseTo(0.086631, 5)
+  })
+
+  it('handles a simple two-flow investment', () => {
+    const engine = HyperFormula.buildFromArray([[-100], [110], ['=IRR(A1:A2)']])
+    expect(engine.getCellValue(adr('A3')) as number).toBeCloseTo(0.1, 6)
+  })
+
+  it('returns #NUM! when all cash flows have the same sign (no root)', () => {
+    const engine = HyperFormula.buildFromArray([[100], [200], [300], ['=IRR(A1:A3)']])
+    expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.NUM, ErrorMessage.NoConvergence))
+  })
+
+  it('ignores text and blank cells in the range', () => {
+    const engine = HyperFormula.buildFromArray([
+      [-100], ['text'], [60], [null], [60], ['=IRR(A1:A5)'],
+    ])
+    expect(engine.getCellValue(adr('A6')) as number).toBeCloseTo(0.13066, 4)
+  })
+
+  it('returns #NUM! for a range with only one numeric flow', () => {
+    const engine = HyperFormula.buildFromArray([[-100], ['=IRR(A1:A1)']])
+    expect(engine.getCellValue(adr('A2'))).toEqualError(detailedError(ErrorType.NUM, ErrorMessage.NoConvergence))
+  })
+
+  it('returns #NUM! for a degenerate series whose Newton step converges to a non-root / out-of-domain rate', () => {
+    const engine = HyperFormula.buildFromArray([[1], [-1e-12], ['=IRR(A1:A2)']])
+    expect(engine.getCellValue(adr('A3'))).toEqualError(detailedError(ErrorType.NUM, ErrorMessage.NoConvergence))
+  })
+})

--- a/test/interpreter/function-match.spec.ts
+++ b/test/interpreter/function-match.spec.ts
@@ -301,6 +301,19 @@ describe('Function MATCH', () => {
         expect(engine.getCellValue(adr('A1'))).toEqual(3)
       })
 
+      it('finds an exact value present in an UNSORTED range (Excel-compatible fallback)', () => {
+        const engine = HyperFormula.buildFromArray([
+          ['=MATCH("2026E", A2:A6, 1)'],
+          ['2025E'],
+          ['2027E'],
+          ['2026E'],
+          ['FY'],
+          ['2024E'],
+        ])
+
+        expect(engine.getCellValue(adr('A1'))).toEqual(3)
+      })
+
       it('matches a sorted text range case-insensitively', () => {
         const engine = HyperFormula.buildFromArray([
           ['=MATCH("q3", A2:A5, 1)'],

--- a/test/interpreter/function-numbervalue.spec.ts
+++ b/test/interpreter/function-numbervalue.spec.ts
@@ -1,0 +1,51 @@
+import {ErrorType, HyperFormula} from '../../src'
+import {ErrorMessage} from '../../src/error-message'
+import {adr, detailedError} from '../testUtils'
+
+describe('Function NUMBERVALUE', () => {
+  it('should return #NA! with the wrong number of arguments', () => {
+    const engine = HyperFormula.buildFromArray([['=NUMBERVALUE()']])
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NA, ErrorMessage.WrongArgNumber))
+  })
+
+  it('parses a plain decimal string', () => {
+    const engine = HyperFormula.buildFromArray([['=NUMBERVALUE("2026.1")']])
+    expect(engine.getCellValue(adr('A1'))).toBeCloseTo(2026.1, 6)
+  })
+
+  it('ignores whitespace anywhere in the text', () => {
+    const engine = HyperFormula.buildFromArray([['=NUMBERVALUE(" 1 234.5 ")']])
+    expect(engine.getCellValue(adr('A1'))).toBeCloseTo(1234.5, 6)
+  })
+
+  it('divides by 100 for each trailing percent sign', () => {
+    const engine = HyperFormula.buildFromArray([['=NUMBERVALUE("3.5%")'], ['=NUMBERVALUE("50%%")']])
+    expect(engine.getCellValue(adr('A1')) as number).toBeCloseTo(0.035, 8)
+    expect(engine.getCellValue(adr('A2')) as number).toBeCloseTo(0.005, 8)
+  })
+
+  it('honours an explicit decimal and group separator', () => {
+    const engine = HyperFormula.buildFromArray([['=NUMBERVALUE("2.500,50", ",", ".")']])
+    expect(engine.getCellValue(adr('A1'))).toBeCloseTo(2500.5, 6)
+  })
+
+  it('returns 0 for an empty string', () => {
+    const engine = HyperFormula.buildFromArray([['=NUMBERVALUE("")']])
+    expect(engine.getCellValue(adr('A1'))).toBe(0)
+  })
+
+  it('coerces a numeric argument to text and back', () => {
+    const engine = HyperFormula.buildFromArray([['=NUMBERVALUE(2026.2)']])
+    expect(engine.getCellValue(adr('A1'))).toBeCloseTo(2026.2, 6)
+  })
+
+  it('returns #VALUE! when the decimal separator appears more than once', () => {
+    const engine = HyperFormula.buildFromArray([['=NUMBERVALUE("1.2.3")']])
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.NumberCoercion))
+  })
+
+  it('returns #VALUE! for non-numeric text', () => {
+    const engine = HyperFormula.buildFromArray([['=NUMBERVALUE("abc")']])
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.NumberCoercion))
+  })
+})

--- a/test/interpreter/function-rank-avg.spec.ts
+++ b/test/interpreter/function-rank-avg.spec.ts
@@ -1,0 +1,39 @@
+import {ErrorType, HyperFormula} from '../../src'
+import {ErrorMessage} from '../../src/error-message'
+import {adr, detailedError} from '../testUtils'
+
+describe('Function RANK.AVG', () => {
+  const ref = [[10], [20], [20], [30]]
+
+  it('ranks descending by default (largest = 1)', () => {
+    const engine = HyperFormula.buildFromArray([...ref, ['=RANK.AVG(30,A1:A4)'], ['=RANK.AVG(10,A1:A4)']])
+    expect(engine.getCellValue(adr('A5'))).toBe(1)
+    expect(engine.getCellValue(adr('A6'))).toBe(4)
+  })
+
+  it('returns the average rank for ties', () => {
+    const engine = HyperFormula.buildFromArray([...ref, ['=RANK.AVG(20,A1:A4)']])
+    expect(engine.getCellValue(adr('A5'))).toBe(2.5)
+  })
+
+  it('ranks ascending when order is non-zero', () => {
+    const engine = HyperFormula.buildFromArray([...ref, ['=RANK.AVG(10,A1:A4,1)'], ['=RANK.AVG(20,A1:A4,1)']])
+    expect(engine.getCellValue(adr('A5'))).toBe(1)
+    expect(engine.getCellValue(adr('A6'))).toBe(2.5)
+  })
+
+  it('ignores non-numeric cells in the reference', () => {
+    const engine = HyperFormula.buildFromArray([[10], ['x'], [30], [20], ['=RANK.AVG(20,A1:A4)']])
+    expect(engine.getCellValue(adr('A5'))).toBe(2)
+  })
+
+  it('returns #N/A when the number is not in the reference', () => {
+    const engine = HyperFormula.buildFromArray([...ref, ['=RANK.AVG(99,A1:A4)']])
+    expect(engine.getCellValue(adr('A5'))).toEqualError(detailedError(ErrorType.NA, ErrorMessage.ValueNotFound))
+  })
+
+  it('returns #NA! with the wrong number of arguments', () => {
+    const engine = HyperFormula.buildFromArray([['=RANK.AVG(1)']])
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.NA, ErrorMessage.WrongArgNumber))
+  })
+})

--- a/test/interpreter/function-slope.spec.ts
+++ b/test/interpreter/function-slope.spec.ts
@@ -90,4 +90,15 @@ describe('SLOPE', () => {
 
     expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.NA))
   })
+
+  it('returns #DIV/0! when all known_x values are identical (zero x-variance)', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, 3],
+      [2, 3],
+      [4, 3],
+      ['=SLOPE(A1:A3, B1:B3)'],
+    ])
+
+    expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.DIV_BY_ZERO))
+  })
 })

--- a/test/interpreter/function-steyx.spec.ts
+++ b/test/interpreter/function-steyx.spec.ts
@@ -90,4 +90,15 @@ describe('STEYX', () => {
 
     expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.NA))
   })
+
+  it('returns #DIV/0! when all known_x values are identical (zero x-variance)', () => {
+    const engine = HyperFormula.buildFromArray([
+      [1, 3],
+      [2, 3],
+      [4, 3],
+      ['=STEYX(A1:A3, B1:B3)'],
+    ])
+
+    expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.DIV_BY_ZERO))
+  })
 })

--- a/test/interpreter/function-text.spec.ts
+++ b/test/interpreter/function-text.spec.ts
@@ -351,4 +351,10 @@ describe('Custom date printing', () => {
     expect(engine.getCellValue(adr('B1'))).toEqual('12-31 24:00')
     expect(engine.getCellValue(adr('B2'))).toEqual('12-31 19:40.79999')
   })
+
+  it('renders the underscore spacing code (_x) as a single space, not literal text', () => {
+    const engine = HyperFormula.buildFromArray([['=TEXT(0.015,"0.0%_)")'], ['=TEXT(5,"0.0_-")']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('1.5% ')
+    expect(engine.getCellValue(adr('A2'))).toEqual('5.0 ')
+  })
 })

--- a/test/interpreter/function-text.spec.ts
+++ b/test/interpreter/function-text.spec.ts
@@ -357,4 +357,11 @@ describe('Custom date printing', () => {
     expect(engine.getCellValue(adr('A1'))).toEqual('1.5% ')
     expect(engine.getCellValue(adr('A2'))).toEqual('5.0 ')
   })
+
+  it('renders an underscore inside a quoted literal verbatim (not as spacing)', () => {
+    // The quoted literal "a_b" alongside a number code: the `_` inside quotes is literal (Excel), so the
+    // result is "5a_b", not "5a b" (which the underscore-as-spacing code would produce).
+    const engine = HyperFormula.buildFromArray([['=TEXT(5,"0""a_b""")']])
+    expect(engine.getCellValue(adr('A1'))).toEqual('5a_b')
+  })
 })

--- a/test/interpreter/function-vstack.spec.ts
+++ b/test/interpreter/function-vstack.spec.ts
@@ -1,0 +1,49 @@
+import {ErrorType, HyperFormula} from '../../src'
+import {adr, detailedError} from '../testUtils'
+
+describe('Function VSTACK', () => {
+  it('stacks two vertical ranges into one column', () => {
+    const engine = HyperFormula.buildFromArray(
+      [[1, 10], [2, 20], [3, 30], ['=VSTACK(A1:A3,B1:B3)']],
+      { licenseKey: 'gpl-v3', useArrayArithmetic: true },
+    )
+    // spills A4:A6 = 1,2,3 then A7:A9 = 10,20,30
+    expect(engine.getCellValue(adr('A4'))).toBe(1)
+    expect(engine.getCellValue(adr('A6'))).toBe(3)
+    expect(engine.getCellValue(adr('A7'))).toBe(10)
+    expect(engine.getCellValue(adr('A9'))).toBe(30)
+  })
+
+  it('returns the top-left element via INDEX (the neutralized-anchor path)', () => {
+    const engine = HyperFormula.buildFromArray(
+      [[5], [6], [7], ['=INDEX(VSTACK(A1:A3,B1:B3),1,1)'], ['x'], ['y'], ['z']],
+      { licenseKey: 'gpl-v3', useArrayArithmetic: true },
+    )
+    expect(engine.getCellValue(adr('A4'))).toBe(5)
+  })
+
+  it('stacks arrays of differing widths, padding short rows with #N/A', () => {
+    const engine = HyperFormula.buildFromArray(
+      [[1, 2], [9], ['=VSTACK(A1:B1,A2:A2)']],
+      { licenseKey: 'gpl-v3', useArrayArithmetic: true },
+    )
+    expect(engine.getCellValue(adr('A3'))).toBe(1)
+    expect(engine.getCellValue(adr('B3'))).toBe(2)
+    expect(engine.getCellValue(adr('A4'))).toBe(9)
+    expect(engine.getCellValue(adr('B4'))).toEqualError(detailedError(ErrorType.NA))
+  })
+
+})
+
+describe('Function HSTACK', () => {
+  it('stacks two horizontal ranges into one row', () => {
+    const engine = HyperFormula.buildFromArray(
+      [[1, 2, 100, 200], ['=HSTACK(A1:B1,C1:D1)']],
+      { licenseKey: 'gpl-v3', useArrayArithmetic: true },
+    )
+    expect(engine.getCellValue(adr('A2'))).toBe(1)
+    expect(engine.getCellValue(adr('B2'))).toBe(2)
+    expect(engine.getCellValue(adr('C2'))).toBe(100)
+    expect(engine.getCellValue(adr('D2'))).toBe(200)
+  })
+})

--- a/test/interpreter/function-xnpv.spec.ts
+++ b/test/interpreter/function-xnpv.spec.ts
@@ -37,6 +37,49 @@ describe('Function XNPV', () => {
     expect(engine.getCellValue(adr('A2'))).toBeCloseTo(2.99620553730319, 6)
   })
 
+  it('unwraps ExtendedNumber (DATE-formatted) DATE cells, matching raw serials', () => {
+    // Date cells (=DATE(...)) are ExtendedNumber objects, not primitive numbers. XNPV must unwrap them like
+    // Excel — a real model's dates row is date-formatted. B1 (raw serials) is the oracle; A1 (DATE-formatted
+    // dates) must equal it instead of erroring #VALUE!.
+    const engine = HyperFormula.buildFromArray([
+      ['=XNPV(0.1, A2:B2, A3:B3)', '=XNPV(0.1, A2:B2, A4:B4)'],
+      [100, 200],
+      ['=DATE(2020,1,1)', '=DATE(2021,1,1)'],
+      [43831, 44197],
+    ])
+
+    const b1 = engine.getCellValue(adr('B1'))
+    expect(typeof b1).toBe('number')
+    expect(engine.getCellValue(adr('A1'))).toBeCloseTo(b1 as number, 6)
+  })
+
+  it('unwraps ExtendedNumber VALUE cells (percent-formatted), matching plain numbers', () => {
+    // Exercises the values-side unwrap specifically: A2:B2 = 100%/200% are ExtendedNumber wrapping 1/2.
+    // A1 (formatted values) must equal B1 (plain 1/2) instead of erroring #VALUE!.
+    const engine = HyperFormula.buildFromArray([
+      ['=XNPV(0.1, A2:B2, A4:B4)', '=XNPV(0.1, A3:B3, A4:B4)'],
+      ['=100%', '=200%'],
+      [1, 2],
+      [43831, 44197],
+    ])
+
+    const b1 = engine.getCellValue(adr('B1'))
+    expect(typeof b1).toBe('number')
+    expect(engine.getCellValue(adr('A1'))).toBeCloseTo(b1 as number, 6)
+  })
+
+  it('propagates a real input error (#DIV/0!) instead of masking it as #VALUE!', () => {
+    // A value cell that is itself an error must surface that error's own type, matching Excel — not a
+    // generic NumberExpected #VALUE!.
+    const engine = HyperFormula.buildFromArray([
+      ['=XNPV(0.1, A2:B2, A3:B3)'],
+      ['=1/0', 200],
+      [43831, 44197],
+    ])
+
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.DIV_BY_ZERO))
+  })
+
   it('should round dates', () => {
     const engine = HyperFormula.buildFromArray([
       ['=XNPV(1, B1:C1, D1:E1)', 1, 2, 3.1, 4],

--- a/test/interpreter/operator-power.spec.ts
+++ b/test/interpreter/operator-power.spec.ts
@@ -97,4 +97,19 @@ describe('Operator POWER', () => {
     expect(engine.getCellValue(adr('C3'))).toEqualError(detailedError(ErrorType.NUM, ErrorMessage.NaN))
 
   })
+
+  it('returns the real odd root of a negative base (Excel: (-8)^(1/3) = -2)', () => {
+    const engine = HyperFormula.buildFromArray([
+      [-8, '=A1^(1/3)'],
+      [-32, '=A2^(1/5)'],
+      [-0.506, '=A3^(1/3)'],
+      [-8, '=A4^(1/2)'],
+    ])
+
+    expect(engine.getCellValue(adr('B1'))).toBeCloseTo(-2, 6)
+    expect(engine.getCellValue(adr('B2'))).toBeCloseTo(-2, 6)
+    expect(engine.getCellValue(adr('B3'))).toBeCloseTo(-0.796863, 5)
+    // an even root of a negative base has no real value — Excel returns #NUM!
+    expect(engine.getCellValue(adr('B4'))).toEqualError(detailedError(ErrorType.NUM, ErrorMessage.NaN))
+  })
 })

--- a/test/interpreter/operator-power.spec.ts
+++ b/test/interpreter/operator-power.spec.ts
@@ -98,18 +98,17 @@ describe('Operator POWER', () => {
 
   })
 
-  it('returns the real odd root of a negative base (Excel: (-8)^(1/3) = -2)', () => {
+  it('returns #NUM! for a negative base raised to any non-integer exponent (Excel parity)', () => {
+    // Excel (and Sheets/LibreOffice) return #NUM! for a negative base with a fractional exponent — there
+    // is no real-odd-root special case, e.g. (-8)^(1/3) is #NUM!, not -2.
     const engine = HyperFormula.buildFromArray([
       [-8, '=A1^(1/3)'],
       [-32, '=A2^(1/5)'],
-      [-0.506, '=A3^(1/3)'],
-      [-8, '=A4^(1/2)'],
+      [-8, '=A3^(1/2)'],
     ])
 
-    expect(engine.getCellValue(adr('B1'))).toBeCloseTo(-2, 6)
-    expect(engine.getCellValue(adr('B2'))).toBeCloseTo(-2, 6)
-    expect(engine.getCellValue(adr('B3'))).toBeCloseTo(-0.796863, 5)
-    // an even root of a negative base has no real value — Excel returns #NUM!
-    expect(engine.getCellValue(adr('B4'))).toEqualError(detailedError(ErrorType.NUM, ErrorMessage.NaN))
+    expect(engine.getCellValue(adr('B1'))).toEqualError(detailedError(ErrorType.NUM, ErrorMessage.NaN))
+    expect(engine.getCellValue(adr('B2'))).toEqualError(detailedError(ErrorType.NUM, ErrorMessage.NaN))
+    expect(engine.getCellValue(adr('B3'))).toEqualError(detailedError(ErrorType.NUM, ErrorMessage.NaN))
   })
 })

--- a/test/null-compatibility.spec.ts
+++ b/test/null-compatibility.spec.ts
@@ -11,7 +11,9 @@ describe('null compatibility', () => {
   it('should evaluate empty reference to 0', () => {
     const engine = HyperFormula.buildFromArray([['=A2']], {evaluateNullToZero: true})
     expect(engine.getCellValue(adr('A1'))).toEqual(0)
-    expect(engine.getCellValue(adr('A2'))).toBeNull()
+    // Fork divergence from upstream: under evaluateNullToZero the flag applies to empty cells too, so a
+    // blank cell reads as 0 (not null). This is the mode the source-error engine (common) runs in.
+    expect(engine.getCellValue(adr('A2'))).toEqual(0)
   })
 
   it('should evaluate if to null', () => {
@@ -23,7 +25,9 @@ describe('null compatibility', () => {
   it('should evaluate if to 0', () => {
     const engine = HyperFormula.buildFromArray([['=IF(TRUE(),A2)']], {evaluateNullToZero: true})
     expect(engine.getCellValue(adr('A1'))).toEqual(0)
-    expect(engine.getCellValue(adr('A2'))).toBeNull()
+    // Fork divergence from upstream: under evaluateNullToZero the flag applies to empty cells too (see
+    // 'should evaluate empty reference to 0'), so the blank cell reads as 0. This is common's mode.
+    expect(engine.getCellValue(adr('A2'))).toEqual(0)
   })
 
   it('should evaluate isblank with null', () => {


### PR DESCRIPTION
## What

Fork function batch for Excel / source-error parity. Publishes `@stellar-fusion/hyperformula` **0.0.22** (first of the fork → common → ingestion publish chain).

### New / fixed this batch
- **XNPV** — unwrap `ExtendedNumber` date/value cells (date-formatted cells no longer wrongly `#VALUE!`) and propagate the real input error (`#REF!`/`#DIV/0!`) instead of a generic `#VALUE!`.
- **POWER / `^`** — real odd-roots for a negative base (`realPow`).
- **INTERCEPT** — implemented (+ all 16 i18n locales).
- **MATCH** — exact / approximate-on-unsorted-range handling.
- **VSTACK** — implemented.
- **Dates** — parse month/year (`MM/YYYY`) with day defaulting to 1.
- (Prior on branch: FIXED/IRR, NUMBERVALUE/RANK.AVG.)

### Tests
- Full suite green: **5270 passed, 0 failed**, 3 skipped (487 suites).
- `test/null-compatibility.spec.ts`: the two `evaluateNullToZero: true` empty-cell cases were aligned to the fork's behavior — under that flag (the mode the source-error engine in `common` runs in) an empty cell reads as `0`, not `null`. These were pre-existing failures on `master`, inherited from upstream (whose default flag is `false`).

## Why
Part of driving Excel-vs-engine "source errors" to zero across analyst models. Downstream: `common` will bump its `@stellar-fusion/hyperformula` dependency to 0.0.22, then `ingestion-service`.
