### PR TITLE
feat: fork function batch (coercion, SINGLE, XNPV, FIXED, IRR, …) → 0.0.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"

--- a/src/i18n/languages/csCZ.ts
+++ b/src/i18n/languages/csCZ.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SEKUNDA',
     SHEET: 'SHEET',
     SHEETS: 'SHEETS',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'ODPIS.LIN',

--- a/src/i18n/languages/daDK.ts
+++ b/src/i18n/languages/daDK.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SEKUND',
     SHEET: 'ARK',
     SHEETS: 'ARK.FLERE',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'LA',

--- a/src/i18n/languages/deDE.ts
+++ b/src/i18n/languages/deDE.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SEKUNDE',
     SHEET: 'BLATT',
     SHEETS: 'BLÄTTER',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINHYP',
     SLN: 'LIA',

--- a/src/i18n/languages/enGB.ts
+++ b/src/i18n/languages/enGB.ts
@@ -200,6 +200,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SECOND',
     SHEET: 'SHEET',
     SHEETS: 'SHEETS',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'SLN',

--- a/src/i18n/languages/esES.ts
+++ b/src/i18n/languages/esES.ts
@@ -198,6 +198,7 @@ export const dictionary: RawTranslationPackage = {
     SECOND: 'SEGUNDO',
     SHEET: 'HOJA',
     SHEETS: 'HOJAS',
+    SINGLE: 'SINGLE',
     SIN: 'SENO',
     SINH: 'SENOH',
     SLN: 'SLN',

--- a/src/i18n/languages/fiFI.ts
+++ b/src/i18n/languages/fiFI.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SEKUNNIT',
     SHEET: 'TAULUKKO',
     SHEETS: 'TAULUKOT',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'STP',

--- a/src/i18n/languages/frFR.ts
+++ b/src/i18n/languages/frFR.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SECONDE',
     SHEET: 'FEUILLE',
     SHEETS: 'FEUILLES',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'AMORLIN',

--- a/src/i18n/languages/huHU.ts
+++ b/src/i18n/languages/huHU.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'MPERC',
     SHEET: 'LAP',
     SHEETS: 'LAPOK',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'LCSA',

--- a/src/i18n/languages/itIT.ts
+++ b/src/i18n/languages/itIT.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SECONDO',
     SHEET: 'FOGLIO',
     SHEETS: 'FOGLI',
+    SINGLE: 'SINGLE',
     SIN: 'SEN',
     SINH: 'SENH',
     SLN: 'AMMORT.COST',

--- a/src/i18n/languages/nbNO.ts
+++ b/src/i18n/languages/nbNO.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SEKUND',
     SHEET: 'ARK',
     SHEETS: 'SHEETS',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'LINAVS',

--- a/src/i18n/languages/nlNL.ts
+++ b/src/i18n/languages/nlNL.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SECONDE',
     SHEET: 'BLAD',
     SHEETS: 'BLADEN',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'LIN.AFSCHR',

--- a/src/i18n/languages/plPL.ts
+++ b/src/i18n/languages/plPL.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SEKUNDA',
     SHEET: 'ARKUSZ',
     SHEETS: 'ARKUSZE',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'SLN',

--- a/src/i18n/languages/ptPT.ts
+++ b/src/i18n/languages/ptPT.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SEGUNDO',
     SHEET: 'PLANILHA',
     SHEETS: 'PLANILHAS',
+    SINGLE: 'SINGLE',
     SIN: 'SEN',
     SINH: 'SENH',
     SLN: 'DPD',

--- a/src/i18n/languages/ruRU.ts
+++ b/src/i18n/languages/ruRU.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'СЕКУНДЫ',
     SHEET: 'ЛИСТ',
     SHEETS: 'ЛИСТЫ',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'АПЛ',

--- a/src/i18n/languages/svSE.ts
+++ b/src/i18n/languages/svSE.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SEKUND',
     SHEET: 'SHEET',
     SHEETS: 'SHEETS',
+    SINGLE: 'SINGLE',
     SIN: 'SIN',
     SINH: 'SINH',
     SLN: 'LINAVSKR',

--- a/src/i18n/languages/trTR.ts
+++ b/src/i18n/languages/trTR.ts
@@ -198,6 +198,7 @@ const dictionary: RawTranslationPackage = {
     SECOND: 'SANİYE',
     SHEET: 'SAYFA',
     SHEETS: 'SAYFALAR',
+    SINGLE: 'SINGLE',
     SIN: 'SİN',
     SINH: 'SINH',
     SLN: 'DA',

--- a/src/interpreter/ArithmeticHelper.ts
+++ b/src/interpreter/ArithmeticHelper.ts
@@ -650,7 +650,16 @@ export function coerceScalarToString(arg: InternalScalarValue): string | CellErr
   } else if (arg === EmptyValue) {
     return ''
   } else if (isExtendedNumber(arg)) {
-    return getRawValue(arg).toString()
+    const raw = getRawValue(arg)
+    /* Excel coerces a number to text via its General format, which rounds to 15 significant digits.
+     * Without this, binary floating-point noise leaks into string operations — e.g. 2026.3+0.1
+     * stringifies as "2026.3999999999999", so RIGHT(...,1) returns "9" instead of "4" and breaks
+     * period-code / text-parsing formulas. Mirrors the display rounding in format.ts's numberFormat.
+     * 0, non-finite, and >=1e15 magnitudes are returned as-is (toPrecision would add e-notation). */
+    if (typeof raw === 'number' && raw !== 0 && isFinite(raw) && Math.abs(raw) < 1e15) {
+      return Number(raw.toPrecision(15)).toString()
+    }
+    return raw.toString()
   } else {
     return arg ? 'TRUE' : 'FALSE'
   }

--- a/src/interpreter/plugin/InformationPlugin.ts
+++ b/src/interpreter/plugin/InformationPlugin.ts
@@ -149,7 +149,26 @@ export class InformationPlugin extends FunctionPlugin implements FunctionPluginT
       ],
       doesNotNeedArgumentsToBeComputed: true,
       vectorizationForbidden: true,
+    },
+    'SINGLE': {
+      method: 'single',
+      parameters: [
+        {argumentType: FunctionArgumentType.SCALAR}
+      ],
     }
+  }
+
+  /**
+   * Corresponds to SINGLE(value) — Excel's implicit-intersection `@` operator (stored as
+   * `_xlfn.SINGLE`). Returns a single value: a scalar argument passes through unchanged, and a
+   * range argument is implicitly intersected to the cell on the formula's row/column (SCALAR
+   * argument coercion), yielding #VALUE! when there is no intersection.
+   *
+   * @param ast
+   * @param state
+   */
+  public single(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(ast.args, state, this.metadata('SINGLE'), (value: InternalScalarValue) => value)
   }
 
   /**

--- a/test/interpreter/coercions.spec.ts
+++ b/test/interpreter/coercions.spec.ts
@@ -160,6 +160,18 @@ describe('#coerceScalarToString', () => {
 
     expect(coerceScalarToString(new CellError(ErrorType.DIV_BY_ZERO))).toEqual(new CellError(ErrorType.DIV_BY_ZERO))
   })
+
+  it('rounds to 15 significant figures like Excel (absorbs binary floating-point noise)', () => {
+    // Excel coerces a number to text via its General format, which uses 15 significant digits.
+    // Without this, `RIGHT(2026.3+0.1,1)` returns "9" (from "2026.3999999999999") instead of "4".
+    expect(coerceScalarToString(2026.3 + 0.1)).toBe('2026.4')
+    expect(coerceScalarToString(0.1 + 0.2)).toBe('0.3')
+    expect(coerceScalarToString(1.1 * 3)).toBe('3.3')
+    // exact values and integers are unaffected
+    expect(coerceScalarToString(2026.4)).toBe('2026.4')
+    expect(coerceScalarToString(123456789)).toBe('123456789')
+    expect(coerceScalarToString(1 / 3)).toBe('0.333333333333333')
+  })
 })
 
 describe('check if type coercions are applied', () => {

--- a/test/interpreter/function-single.spec.ts
+++ b/test/interpreter/function-single.spec.ts
@@ -1,0 +1,44 @@
+import {HyperFormula} from '../../src'
+import {ErrorType} from '../../src/Cell'
+import {ErrorMessage} from '../../src/error-message'
+import {adr, detailedError} from '../testUtils'
+
+describe('Function SINGLE (implicit intersection / @ operator)', () => {
+  it('passes a scalar argument through unchanged', () => {
+    const engine = HyperFormula.buildFromArray([['=SINGLE(5)', '=SINGLE("txt")', '=SINGLE(TRUE())']])
+    expect(engine.getCellValue(adr('A1'))).toEqual(5)
+    expect(engine.getCellValue(adr('B1'))).toEqual('txt')
+    expect(engine.getCellValue(adr('C1'))).toEqual(true)
+  })
+
+  it('passes through the scalar result of a wrapped function (the =_xlfn.SINGLE(AVERAGE(...)) case)', () => {
+    const engine = HyperFormula.buildFromArray([[2, 4, 6, '=SINGLE(AVERAGE(A1:C1))']])
+    expect(engine.getCellValue(adr('D1'))).toEqual(4)
+  })
+
+  it('implicitly intersects a range argument to the cell on the formula row', () => {
+    const engine = HyperFormula.buildFromArray([
+      [10, '=SINGLE(A1:A3)'],
+      [20, '=SINGLE(A1:A3)'],
+      [30, '=SINGLE(A1:A3)'],
+    ])
+    expect(engine.getCellValue(adr('B1'))).toEqual(10)
+    expect(engine.getCellValue(adr('B2'))).toEqual(20)
+    expect(engine.getCellValue(adr('B3'))).toEqual(30)
+  })
+
+  it('column-intersects a horizontal range that shares the formula column', () => {
+    const engine = HyperFormula.buildFromArray([[1, 2, 3], [], [], ['=SINGLE(A1:C1)']])
+    expect(engine.getCellValue(adr('A4'))).toEqual(1)
+  })
+
+  it('returns #VALUE! when a range shares neither row nor column with the formula cell', () => {
+    const engine = HyperFormula.buildFromArray([[null, 1, 2, 3], [], [], ['=SINGLE(B1:D1)']])
+    expect(engine.getCellValue(adr('A4'))).toEqualError(detailedError(ErrorType.VALUE, ErrorMessage.WrongType))
+  })
+
+  it('propagates an error argument', () => {
+    const engine = HyperFormula.buildFromArray([['=SINGLE(1/0)']])
+    expect(engine.getCellValue(adr('A1'))).toEqualError(detailedError(ErrorType.DIV_BY_ZERO))
+  })
+})


### PR DESCRIPTION
## Fork function batch → publish `0.0.23`

Accumulated `@stellar-fusion/hyperformula` fork improvements that have built up on `feat/fork-function-batch` and never been published (origin `master` is still `0.0.22`). Bundling repo (`@stellar-fusion/common`) currently pins `0.0.22`, so **none** of these are in production yet. This bumps to **`0.0.23`** (0.0.22 is already published — avoids a version collision) so `common` can pick them up.

> **Merge order:** this PR is **#1** of the source-error batch. It must merge + publish **before** `common` (which bumps its `@stellar-fusion/hyperformula` dep to `0.0.23`), then ingestion-service + source-error-lambda.

### Source-error correctness fixes (the drivers)

- **Excel 15-significant-figure string coercion** — `coerceScalarToString` now renders finite numbers at Excel's 15 sig-figs (`Number(x.toPrecision(15))`) instead of full float text, so `RIGHT()`/`&`/period-code criteria feeding `SUMIF`/`COUNTIF` match Excel. Fixes REIT-style cascades (e.g. CUBE 200→0 source errors).
- **`_xlfn.SINGLE`** — implemented as an implicit-intersection passthrough (+16 i18n locales); clears `_xlfn.SINGLE` source errors (e.g. AB).
- **`XNPV`** — unwraps `ExtendedNumber` date/value cells and propagates input errors (date-formatted date cells no longer wrongly `#VALUE!`).
- **`FIXED`** — returns `#NUM!` (not `#VALUE!`) for non-finite values, matching Excel.
- **`realPow`** — negative base with a non-integer exponent now returns Excel's `#NUM!` (reverted the real-odd-root special case).
- **`INTERCEPT`/`SLOPE`/`STEYX`** — return `#DIV/0!` on zero x-variance (all `known_x` identical), matching Excel.
- **`TEXT` underscore-space code** + render underscore inside a quoted format literal verbatim (not as spacing).
- **`MM/YYYY` date parsing** — day defaults to 1.
- **`MATCH`** — corrected exact / approximate-on-unsorted-range handling.

### New functions implemented

`VSTACK`, `INTERCEPT`, `NUMBERVALUE`, `RANK.AVG`, `FIXED`, `IRR` (+ i18n locale entries where applicable).

### Validation

- Fork jest suite green (touched specs `function-single`, `coercions` = 34 passing; full suite validated at 5282 passing across the batch).
