### PR TITLE
fix(format+criterion): number-format tokens + empty-criterion Excel parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar-fusion/hyperformula",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "author": "Stellar Fusion Tech <tech@stellarfusion.io>",
   "contributors": [
     "Evan Hynes <evan.hynes@stellarfusion.io>"

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -94,15 +94,40 @@ function formatSection(value: number, formatArg: string, config: Config, dateHel
  * dropped, not honoured — its section is still selected by sign only; full conditional section
  * selection is not modelled (rare in practice, and dropping beats leaking "[>100]" into the cell). */
 function stripDecorativeBrackets(formatArg: string): string {
-  return formatArg.replace(/\[([^\]]*)\]/g, (match, inner) => {
-    if (/^[hHmMsS]+$/.test(inner)) {
-      return match
+  let result = ''
+  let inQuote = false
+  for (let i = 0; i < formatArg.length; i++) {
+    const ch = formatArg[i]
+    // An escaped char (\x) is a display literal — emit both and skip, so \[ / \] survive for the
+    // downstream literal renderer.
+    if (ch === '\\' && i + 1 < formatArg.length) {
+      result += formatArg.slice(i, i + 2)
+      i++
+      continue
     }
-    if (inner.startsWith('$')) {
-      return inner.slice(1).split('-')[0]
+    if (ch === '"') {
+      inQuote = !inQuote
+      result += ch
+      continue
     }
-    return ''
-  })
+    // Only a structural (unquoted, unescaped) bracket is a directive. Inside a quoted literal it is
+    // display text and must survive.
+    if (ch === '[' && !inQuote) {
+      const end = formatArg.indexOf(']', i)
+      if (end !== -1) {
+        const inner = formatArg.slice(i + 1, end)
+        if (/^[hHmMsS]+$/.test(inner)) {
+          result += formatArg.slice(i, end + 1)
+        } else if (inner.startsWith('$')) {
+          result += inner.slice(1).split('-')[0]
+        }
+        i = end
+        continue
+      }
+    }
+    result += ch
+  }
+  return result
 }
 
 export function format(value: number, formatArg: string, config: Config, dateHelper: DateTimeHelper): RawScalarValue {

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -85,7 +85,28 @@ function formatSection(value: number, formatArg: string, config: Config, dateHel
   return formatArg
 }
 
+/* Excel prefixes number formats with square-bracket directives: colour codes ([Red], [Blue],
+ * [Color 3]), condition tests ([>100]), and embedded currency/locale ([$£-809]). None belong to the
+ * numeric pattern — left in place they leak into the output, or (when they contain date letters, e.g.
+ * [Red]'s "d") get mangled by the date parser that runs first. Strip them, EXCEPT elapsed-time
+ * duration tokens ([h]/[hh]/[m]/[mm]/[s]/[ss]) which the date/duration formatter consumes. An
+ * [$symbol-locale] directive renders its currency symbol. ponytail: a condition like [>100] is
+ * dropped, not honoured — its section is still selected by sign only; full conditional section
+ * selection is not modelled (rare in practice, and dropping beats leaking "[>100]" into the cell). */
+function stripDecorativeBrackets(formatArg: string): string {
+  return formatArg.replace(/\[([^\]]*)\]/g, (match, inner) => {
+    if (/^[hHmMsS]+$/.test(inner)) {
+      return match
+    }
+    if (inner.startsWith('$')) {
+      return inner.slice(1).split('-')[0]
+    }
+    return ''
+  })
+}
+
 export function format(value: number, formatArg: string, config: Config, dateHelper: DateTimeHelper): RawScalarValue {
+  formatArg = stripDecorativeBrackets(formatArg)
   const sections = splitFormatSections(formatArg)
   if (sections.length <= 1) {
     return formatSection(value, formatArg, config, dateHelper)
@@ -117,6 +138,15 @@ export function padRight(number: number | string, size: number) {
 
 function countChars(text: string, char: string) {
   return text.split(char).length - 1
+}
+
+/* Insert thousands separators into an already-rendered integer string (e.g. "1234567" -> "1,234,567").
+ * Groups the digits in threes from the right; a leading `-` sign is preserved and not grouped. */
+function addThousandsSeparators(integerPart: string): string {
+  const negative = integerPart.startsWith('-')
+  const digits = negative ? integerPart.slice(1) : integerPart
+  const grouped = digits.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  return negative ? '-' + grouped : grouped
 }
 
 /* Strip Excel format-literal syntax from free text: `\x` escapes (keep x) and `"..."` quote
@@ -183,6 +213,13 @@ function countPercentSigns(tokens: FormatToken[]): number {
     .reduce((count, token) => count + countActivePercent(token.value), 0)
 }
 
+/* Count trailing commas on the number FORMAT token(s) — each scales the displayed value by 1/1000. */
+function countTrailingScalingCommas(tokens: FormatToken[]): number {
+  return tokens
+    .filter((token) => token.type === TokenType.FORMAT)
+    .reduce((count, token) => count + (token.value.match(/,+$/)?.[0].length ?? 0), 0)
+}
+
 /* Excel rounds halves away from zero (2.5 -> 3, -2.5 -> -3), unlike JS toFixed which rounds
  * half-to-even on the binary value. Shifting through the decimal string (rather than value * 10**d)
  * avoids re-introducing floating-point noise. ponytail: values >= 1e15 have no meaningful
@@ -214,6 +251,11 @@ function numberFormat(tokens: FormatToken[], value: number): RawScalarValue {
   const percentSigns = countPercentSigns(tokens)
   value = value * 100 ** percentSigns
 
+  /* A comma directly after the last digit placeholder scales the displayed value DOWN by 1000 per
+   * comma (Excel's "display in thousands / millions"), unlike a comma between digits which groups. */
+  const scalingCommas = countTrailingScalingCommas(tokens)
+  value = value / 1000 ** scalingCommas
+
   /* Excel rounds display values to 15 significant digits. Normalising here absorbs binary
    * floating-point noise (e.g. 0.0295 * 100 === 2.9499999999999997) so the per-token rounding
    * below matches Excel (2.95 -> "3.0%" rather than "2.9%"). `value` is finite here: the
@@ -229,8 +271,15 @@ function numberFormat(tokens: FormatToken[], value: number): RawScalarValue {
       continue
     }
 
-    const tokenParts = token.value.split('.')
-    const integerFormat = tokenParts[0]
+    /* Trailing scaling commas were already applied to `value` above; drop them before parsing the
+     * placeholder pattern so they are not mistaken for grouping. */
+    const tokenParts = token.value.replace(/,+$/, '').split('.')
+    /* A `,` between digit placeholders (e.g. `#,##0`) requests thousands grouping. Strip it before
+     * the padding maths (which counts placeholder width) and re-apply grouping to the rendered
+     * integer digits afterwards. */
+    const integerFormatRaw = tokenParts[0]
+    const useGrouping = integerFormatRaw.includes(',')
+    const integerFormat = integerFormatRaw.replace(/,/g, '')
     const decimalFormat = tokenParts[1] || ''
     const separator = tokenParts[1] ? '.' : ''
 
@@ -246,6 +295,10 @@ function numberFormat(tokens: FormatToken[], value: number): RawScalarValue {
 
     const padSizeDecimal = countChars(decimalFormat.substr(decimalPart.length, decimalFormat.length - decimalPart.length), '0')
     decimalPart = padRight(decimalPart, padSizeDecimal + decimalPart.length)
+
+    if (useGrouping) {
+      integerPart = addThousandsSeparators(integerPart)
+    }
 
     result += integerPart + separator + decimalPart
   }

--- a/src/format/parser.ts
+++ b/src/format/parser.ts
@@ -6,7 +6,7 @@
 import {Maybe} from '../Maybe'
 
 const dateFormatRegex = /(\\.|dd|DD|d|D|mmmmm|MMMMM|mmmm|MMMM|mmm|MMM|mm|MM|m|M|YYYY|YY|yyyy|yy|HH|hh|H|h|ss(\.(0+|s+))?|s|AM\/PM|am\/pm|A\/P|a\/p|\[mm]|\[MM]|\[hh]|\[HH])/g
-const numberFormatRegex = /(\\.|[#0]+(\.[#0]*)?)/g
+const numberFormatRegex = /(\\.|[#0]+([,][#0]+)*(\.[#0]*)?,*)/g
 
 export enum TokenType {
   FORMAT = 'FORMAT',

--- a/src/interpreter/Criterion.ts
+++ b/src/interpreter/Criterion.ts
@@ -34,16 +34,20 @@ export class CriterionBuilder {
   }
 
   public fromCellValue(raw: RawScalarValue, arithmeticHelper: ArithmeticHelper): Maybe<CriterionPackage> {
-    if (typeof raw !== 'string' && typeof raw !== 'boolean' && typeof raw !== 'number') {
+    // Excel treats a reference to an EMPTY cell used as a criterion as the number 0 (matching 0-valued
+    // cells), not an error. Without this, SUMIFS/COUNTIFS/etc. with an empty criterion cell return #VALUE!
+    // ("Incorrect criterion") where Excel computes a value.
+    const scalar = raw === EmptyValue ? 0 : raw
+    if (typeof scalar !== 'string' && typeof scalar !== 'boolean' && typeof scalar !== 'number') {
       return undefined
     }
 
-    const criterion = this.parseCriterion(raw, arithmeticHelper)
+    const criterion = this.parseCriterion(scalar, arithmeticHelper)
     if (criterion === undefined) {
       return undefined
     }
 
-    return {raw, lambda: buildCriterionLambda(criterion, arithmeticHelper)}
+    return {raw: scalar, lambda: buildCriterionLambda(criterion, arithmeticHelper)}
   }
 
   public parseCriterion(criterion: RawScalarValue, arithmeticHelper: ArithmeticHelper): Maybe<Criterion> {

--- a/test/format/format-interpreter.spec.ts
+++ b/test/format/format-interpreter.spec.ts
@@ -162,4 +162,13 @@ describe('FormatInterpreter', () => {
     expect(format(0.1, '[hh]:mm:ss', config, dateHelper)).toEqual('02:24:00')
     expect(format(0.1, '[mm]:ss', config, dateHelper)).toEqual('144:00')
   })
+
+  it('does NOT strip brackets inside a quoted literal (they are display text, not directives)', () => {
+    // A bracket inside a quoted string is literal display text — only structural [..] directives
+    // (colour/condition/locale) are decorative. Stripping quoted brackets mangles valid formats.
+    // (Content avoids date letters d/m/y/h/s, which the fork's date tokenizer mishandles inside
+    // quotes — a separate, pre-existing limitation.)
+    expect(format(5, '0"[x]"', config, dateHelper)).toEqual('5[x]')
+    expect(format(1234, '#,##0" [k]"', config, dateHelper)).toEqual('1,234 [k]')
+  })
 })

--- a/test/format/format-interpreter.spec.ts
+++ b/test/format/format-interpreter.spec.ts
@@ -118,4 +118,48 @@ describe('FormatInterpreter', () => {
     expect(format(12.34, '0.00', config, dateHelper)).toEqual('12.34')
     expect(format(2, 'dd-mm-yyyy', config, dateHelper)).toEqual('01-01-1900')
   })
+
+  it('applies thousands grouping for the #,##0 comma (Excel parity)', () => {
+    // The comma between digit placeholders is a thousands separator. Before the fix the parser
+    // stopped the number token at the comma, leaking ",##0.0" as literal text and dropping the
+    // grouping (the CMG EVRvCons commentary case: "$2,471.9" rendered as "$2472,##0.0").
+    expect(format(2471.9, '#,##0.0', config, dateHelper)).toEqual('2,471.9')
+    expect(format(2471.9, '$#,##0.0', config, dateHelper)).toEqual('$2,471.9')
+    expect(format(2471.9, '#,##0', config, dateHelper)).toEqual('2,472')
+    expect(format(1234567.89, '#,##0.00', config, dateHelper)).toEqual('1,234,567.89')
+    expect(format(11.36, '$#,##0.00', config, dateHelper)).toEqual('$11.36')
+    expect(format(-2471.9, '#,##0.0', config, dateHelper)).toEqual('-2,471.9')
+  })
+
+  it('leaves a comma-free format ungrouped (no regression)', () => {
+    expect(format(2471.9, '0.0', config, dateHelper)).toEqual('2471.9')
+    expect(format(1234, '000', config, dateHelper)).toEqual('1234')
+  })
+
+  it('scales by 1000 for each trailing comma (Excel $-thousands/$-millions display)', () => {
+    // A comma AFTER the last digit placeholder divides the displayed value by 1000 per comma.
+    // Distinct from the grouping comma between digits. Common in models showing "$ in thousands".
+    expect(format(1234567, '#,##0,', config, dateHelper)).toEqual('1,235')
+    expect(format(1234567, '#,##0,,', config, dateHelper)).toEqual('1')
+    expect(format(1500000, '0.0,,', config, dateHelper)).toEqual('1.5')
+    expect(format(2500, '0,', config, dateHelper)).toEqual('3')
+    expect(format(1234567, '#,##0.0,', config, dateHelper)).toEqual('1,234.6')
+  })
+
+  it('strips colour / condition brackets and renders embedded currency symbols', () => {
+    // [Red]/[Blue] colour codes and [>100] conditions are display directives, not part of the number
+    // pattern; unstripped they leak into the output (and [Red]'s "d" gets mangled by the date parser).
+    // [$symbol-locale] renders its currency symbol.
+    expect(format(-5, '[Red]0', config, dateHelper)).toEqual('-5')
+    expect(format(1234, '[Blue]#,##0', config, dateHelper)).toEqual('1,234')
+    expect(format(5, '[Green]0.0', config, dateHelper)).toEqual('5.0')
+    expect(format(5, '[$$-409]#,##0', config, dateHelper)).toEqual('$5')
+    expect(format(5, '[$£-809]#,##0', config, dateHelper)).toEqual('£5')
+  })
+
+  it('does NOT strip elapsed-time duration brackets (regression)', () => {
+    // [hh]/[mm]/[ss] are duration tokens consumed by the date/duration formatter — must survive.
+    expect(format(0.1, '[hh]:mm:ss', config, dateHelper)).toEqual('02:24:00')
+    expect(format(0.1, '[mm]:ss', config, dateHelper)).toEqual('144:00')
+  })
 })

--- a/test/interpreter/function-countifs.spec.ts
+++ b/test/interpreter/function-countifs.spec.ts
@@ -39,6 +39,20 @@ describe('Function COUNTIFS', () => {
     expect(engine.getCellValue(adr('A4'))).toEqual(1)
   })
 
+  it('treats an empty criterion cell as 0 (Excel parity, not #VALUE! "Incorrect criterion")', () => {
+    // C1 is empty; Excel treats a reference to an empty criterion cell as the number 0. Before the fix
+    // this returned #VALUE! "Incorrect criterion" (the ESRT NAV Calc!U4 case). COUNTIFS + SUMIFS both
+    // route through the shared CriterionBuilder.fromCellValue.
+    const engine = HyperFormula.buildFromArray([
+      [0, 10, null, '=COUNTIFS(A1:A3, C1)', '=SUMIFS(B1:B3, A1:A3, C1)'],
+      [1, 20],
+      [0, 30],
+    ])
+
+    expect(engine.getCellValue(adr('D1'))).toEqual(2)   // A1=0, A3=0 match criterion 0
+    expect(engine.getCellValue(adr('E1'))).toEqual(40)  // B1(10) + B3(30) where A=0
+  })
+
   it('use partial cache', () => {
     const engine = HyperFormula.buildFromArray([
       ['0'],

--- a/test/interpreter/function-text.spec.ts
+++ b/test/interpreter/function-text.spec.ts
@@ -212,7 +212,7 @@ describe('TEXT()', () => {
     expect(engine.getCellValue(adr('A6'))).toEqual('$12.450')
     expect(engine.getCellValue(adr('A7'))).toEqual('012.45.00$')
     expect(engine.getCellValue(adr('A8'))).toEqual('12.45.##$')
-    expect(engine.getCellValue(adr('A9'))).toEqual('$12,##0.00')
+    expect(engine.getCellValue(adr('A9'))).toEqual('$12.45')
   })
 
   it('works with currency format "$#.00"', () => {


### PR DESCRIPTION
## What
Two independent engine faithfulness fixes (verified against Excel), bumps `0.0.24 -> 0.0.25`.

**1. Number-format tokens** (`format.ts`, `parser.ts`)
`TEXT()`/number formatting ignored thousands grouping (`#,##0`), trailing scaling commas (`#,##0,` = ÷1000), and decorative brackets (`[Red]`, `[$£-809]`, conditionals). Now applied/stripped to match Excel. Duration brackets (`[hh]`) preserved.

**2. Empty criterion cell** (`Criterion.ts`)
A reference to an empty cell used as a COUNTIFS/SUMIFS criterion returned `#VALUE!`; Excel treats it as `0`. `CriterionBuilder.fromCellValue` now maps `EmptyValue -> 0`.

## Tests
66 pass across format-interpreter, function-countifs, function-text specs (TDD).

## Chain
Head of the publish chain: common bumps this dep next (0.0.25), then consumers.